### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+    - "2.7"
+    - "3.3"
+install:
+    - python setup.py install
+script:
+    - py.test tests/unit


### PR DESCRIPTION
- Add basic Travis CI integration to _Arpeggio_ project. The Travis CI will simply install _Arpeggio_ using `setup.py` script, and run all unit tests in folder `tests/unit`. This will run tests for both Python 3.3.x and Python 2.7.x (this can be changed as necessary). 

TODO: Since I'm not the repository owner, the following things need to be done by repo owner:
1. Read http://docs.travis-ci.com/user/getting-started/ on how authorize Travis CI to access Github account.
2. Push any change to trigger first Travis CI build.
3. Optionally add a status image to README.rst (http://docs.travis-ci.com/user/status-images/) - choose appropriate form from drop down menu on the left.
4. Tweak email notifications. By default Travis CI sends automated mails when builds are broken and when they are repaired (and a mail on first). This may be too frequent, on not frequent enough. See http://docs.travis-ci.com/user/notifications/
