### PR TITLE
experimental fix for textx issue 205

### DIFF
--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -385,7 +385,18 @@ class OrderedChoice(Sequence):
     Will match one of the parser expressions specified. Parser will try to
     match expressions in the order they are defined.
     """
+    def __init__(self, *elements, **kwargs):
+        super(OrderedChoice, self).__init__(*elements, **kwargs)
+
     def _parse(self, parser):
+        if self.ws is not None:
+            old_ws = parser.ws
+            parser.ws = self.ws
+
+        if self.skipws is not None:
+            old_skipws = parser.skipws
+            parser.skipws = self.skipws
+
         result = None
         match = False
         c_pos = parser.position
@@ -398,6 +409,11 @@ class OrderedChoice(Sequence):
                     break
             except NoMatch:
                 parser.position = c_pos  # Backtracking
+            finally:
+                if self.ws is not None:
+                    parser.ws = old_ws
+                if self.skipws is not None:
+                    parser.skipws = old_skipws
 
         if not match:
             parser._nm_raise(self, c_pos, parser)


### PR DESCRIPTION
With this the tests in in https://github.com/textX/textX/blob/bugfix/issue205_skipws_inheritance/tests/functional/regressions/test_issue205_skipws_propagation.py#L61 work...

 * It seems the OrderedChoice did not correctly accept/propagate the skipws flag.
 * Unclear if this is the right "point" for the possible for fix the textx issue.

@igordejanovic, what do you think?