### PR TITLE
Fix setup.cfg not to install any examples

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ tests_require = pytest
 exclude =
     arpeggio.tests
     examples
+    examples.*
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
setup.cfg matches package names exactly, so the additional 'examples.*'
wildcard needs to be specified to prevent example sub-packages
from being installed.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
