### PR TITLE
Error reporting: print newline characters escaped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ nosetests.xml
 *.dot.png
 !docs/**/*.png
 
+# JetBrains IDE artifacts.
+.idea
+
 # Other
 .~lock*
 *.log
@@ -57,3 +60,4 @@ site
 venv
 .ropeproject
 coverage
+

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -878,6 +878,8 @@ class StrMatch(Match):
         super(StrMatch, self).__init__(rule_name, root, **kwargs)
         self.to_match = to_match
         self.ignore_case = ignore_case
+        if "\n" in to_match:
+            self._exp_str = "'" + to_match.replace("\n", "\\n") + "'"
 
     def _parse(self, parser):
         c_pos = parser.position

--- a/arpeggio/tests/test_error_reporting.py
+++ b/arpeggio/tests/test_error_reporting.py
@@ -168,3 +168,15 @@ def test_compound_not_match():
     with pytest.raises(NoMatch) as e:
         parser.parse('   four ident')
     assert "Expected 'one' or 'two' at" in str(e.value)
+
+
+def test_reporting_newline_symbols_when_not_matched():
+    def grammar():
+        return "first", "\n"
+
+    parser = ParserPython(grammar, skipws=False)
+
+    with pytest.raises(NoMatch) as e:
+        _ = parser.parse('first')
+
+    assert "Expected '\\n' at position (1, 6)" in str(e.value)


### PR DESCRIPTION
Hello,

This is a contribution from @mettta and @stanislaw that addresses the issue https://github.com/textX/textX/issues/397.

We are not sure if patching `StrMatch`'s `_exp_str` method is the right way to do it, so using this patch to open a discussion.

When the implementation path is confirmed, we are happy to address the remaining contributor checklist's action points.

---

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
