### PR TITLE
RFC: WIP: More detailed error reporting (reporting full failed expressions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ nosetests.xml
 *.dot.png
 !docs/**/*.png
 
+# JetBrains IDE artifacts.
+.idea
+
 # Other
 .~lock*
 *.log


### PR DESCRIPTION
Hello,

This is our (@mettta and @stanislaw) attempt to make a step towards more precise error reporting.

This slightly more simple implementation at first sacrifices some of the previous capabilities, such as "not reporting the whole failed expression, but only it's failed part". However, these capabilities can be implemented outside the `_nm_raise` method.

I would be curious to hear from you if you consider this to be going to the right direction. In the meantime, I would like to focus on implementing this capability given the direction taken in this patch:

```
def test_optional_with_better_match():
    ...
    # The reporting capability has degraded because we are printing the whole
    # failed expression but an optimization is possible within the parsing code
    # of Sequence.
    #     assert "Expected 'five'" in str(e.value)
    #     assert (e.value.line, e.value.col) == (1, 20)
    assert "Expected (('one' AND 'two' AND 'three' AND '4') OR Optional(('one' AND 'two' AND 'three' AND 'four' AND 'five')))" in str(e.value)
    assert (e.value.line, e.value.col) == (1, 1)
```

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
