### PR TITLE
WIP: Several improvements in error reporting 

### DIFF
--- a/arpeggio/tests/regressions/issue_20/test_issue_20.py
+++ b/arpeggio/tests/regressions/issue_20/test_issue_20.py
@@ -25,4 +25,6 @@ def test_optional_in_choice():
     with pytest.raises(NoMatch) as e:
         parser.parse(input_str)
 
-    assert "Expected 'first' or EOF" in str(e.value)
+    assert (
+        "Expected 'first' or EOF at position (1, 1) => '*second'."
+   ) == str(e.value)


### PR DESCRIPTION
This patch is more advanced compared to https://github.com/textX/Arpeggio/pull/100

WIP checklist:

- [ ] Fix `weakly_failed_rules__`.
- [ ] Revert this line: `# Unsuccessful match of the whole PE - full backtracking`.

The NoMatch class is made smarter and tracks the exact match errors. With this design, reporting an error translates to printing the diagnostics of all failed subexpressions of a failed expression.

For example, for `Sequence`, the `SequenceNoMatch` class collects the failed expression as well as all previously matched (but failed) `Optional` expressions.

The naming of `*NoMatch` certainly introduces some redundancy in the class names, however, without this measure I had hard time visualizing the internal structure of the failed expression to be printed.

Open question:

- Is this desirable that in case of ordered choices, we could print not only the winning match but all matches that are equally possible, as in this example:

```
assert (
    "Expected '4' at position (1, 15)"
    " or "
    "'five' at position (1, 20)" in str(e.value)
 )
```

The advantage of this approach would be that a user sees all alternatives that are possible in cases like this. The cost: the implementation has to control whether several `at position` strings have to be presented instead of a single `at position` at the end of the inspection message.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
