### PR TITLE
tests/test_error_reporting: more specific assert statements

### DIFF
--- a/arpeggio/tests/test_error_reporting.py
+++ b/arpeggio/tests/test_error_reporting.py
@@ -24,7 +24,9 @@ def test_non_optional_precedence():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('c')
-    assert "Expected 'a' or 'b'" in str(e.value)
+    assert (
+        "Expected 'a' or 'b' at position (1, 1) => '*c'."
+    ) == str(e.value)
     assert (e.value.line, e.value.col) == (1, 1)
 
     # This grammar always succeeds due to the optional match
@@ -51,7 +53,9 @@ def test_optional_with_better_match():
     with pytest.raises(NoMatch) as e:
         parser.parse('one two three four 5')
 
-    assert "Expected 'five'" in str(e.value)
+    assert (
+       "Expected 'five' at position (1, 20) => 'hree four *5'."
+    ) == str(e.value)
     assert (e.value.line, e.value.col) == (1, 20)
 
 
@@ -68,7 +72,9 @@ def test_alternative_added():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('   three ident')
-    assert "Expected 'one' or 'two'" in str(e.value)
+    assert (
+       "Expected 'one' or 'two' at position (1, 4) => '   *three iden'."
+    ) == str(e.value)
     assert (e.value.line, e.value.col) == (1, 4)
 
 
@@ -83,7 +89,9 @@ def test_file_name_reporting():
 
     with pytest.raises(NoMatch) as e:
         parser.parse("\n\n   a c", file_name="test_file.peg")
-    assert "Expected 'b' at position test_file.peg:(3, 6)" in str(e.value)
+    assert (
+        "Expected 'b' at position test_file.peg:(3, 6) => '     a *c'."
+    ) == str(e.value)
     assert (e.value.line, e.value.col) == (3, 6)
 
 
@@ -99,7 +107,9 @@ def test_comment_matching_not_reported():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('\n\n a // This is a comment \n c')
-    assert "Expected 'b' at position (4, 2)" in str(e.value)
+    assert (
+       "Expected 'b' at position (4, 2) => 'comment   *c'."
+    ) == str(e.value)
     assert (e.value.line, e.value.col) == (4, 2)
 
 
@@ -116,7 +126,11 @@ def test_not_match_at_beginning():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('   one ident')
-    assert "Not expected input" in str(e.value)
+    # FIXME: It would be great to have the error reported at (1, 4) because the
+    # whitespace is consumed.
+    assert (
+        "Not expected input at position (1, 1) => '*   one ide'."
+    ) == str(e.value)
 
 
 def test_not_match_as_alternative():
@@ -132,7 +146,9 @@ def test_not_match_as_alternative():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('   two ident')
-    assert "Expected 'one' at " in str(e.value)
+    assert (
+        "Expected 'one' at position (1, 4) => '   *two ident'."
+    ) == str(e.value)
 
 
 def test_sequence_of_nots():
@@ -147,7 +163,9 @@ def test_sequence_of_nots():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('   two ident')
-    assert "Not expected input" in str(e.value)
+    assert (
+        "Not expected input at position (1, 4) => '   *two ident'."
+    ) == str(e.value)
 
 
 def test_compound_not_match():
@@ -161,7 +179,9 @@ def test_compound_not_match():
 
     with pytest.raises(NoMatch) as e:
         parser.parse('   three ident')
-    assert "Expected 'one' or 'two' at" in str(e.value)
+    assert (
+        "Expected 'one' or 'two' at position (1, 4) => '   *three iden'."
+    ) == str(e.value)
 
     parser.parse('   four ident')
 
@@ -191,7 +211,9 @@ def test_reporting_newline_symbols_when_not_matched():
     with pytest.raises(NoMatch) as e:
         _ = parser.parse('first')
 
-    assert "Expected '\\n' at position (1, 6)" in str(e.value)
+    assert (
+        "Expected '\\n' at position (1, 6) => 'first*'."
+    ) == str(e.value)
 
     # A case when regex match has newline
     from arpeggio import RegExMatch


### PR DESCRIPTION
Setting the exact string match expectations helps to visualize what exactly changes with any attempts to refactor the error reporting functionality.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated

Seems not applicable:

- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
