### PR TITLE
tests/test_parsing_expressions: more specific assert statements

### DIFF
--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -551,7 +551,7 @@ class OneOrMore(Repetition):
 
 class UnorderedGroup(Repetition):
     """
-    Will try to match all of the parsing expression in any order.
+    Will try to match all the parsing expressions in any order.
     """
     def _parse(self, parser):
         results = []


### PR DESCRIPTION
Setting the exact string match expectations helps to visualize what exactly changes with any attempts to refactor the error reporting functionality.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated

Doesn't seem to be applicable:

- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
