### PR TITLE
WIP: Optional feature: More verbose failed expression reporting

### DIFF
--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -512,8 +512,12 @@ class Sequence(ParsingExpression):
             for e in self.nodes:
                 result = e.parse(parser)
                 if result is not None:
+                    if parser.verbose2 and isinstance(result, list) and len(result) == 0:
+                        parser.weakly_failed_errors.append((c_pos, e))
                     append(result)
-
+                else:
+                    if parser.verbose2:
+                        parser.weakly_failed_errors.append((c_pos, e))
         except NoMatch:
             parser.position = c_pos     # Backtracking
             raise
@@ -635,6 +639,8 @@ class ZeroOrMore(Repetition):
                 append(result)
             except NoMatch:
                 parser.position = c_pos  # Backtracking
+                if parser.verbose2:
+                    parser.weakly_failed_errors.append((c_pos, self.nodes[0]))
                 break
 
         if self.eolterm:

--- a/arpeggio/tests/test_error_reporting.py
+++ b/arpeggio/tests/test_error_reporting.py
@@ -90,7 +90,7 @@ def test_file_name_reporting():
     with pytest.raises(NoMatch) as e:
         parser.parse("\n\n   a c", file_name="test_file.peg")
     assert (
-        "Expected 'b' at position test_file.peg:(3, 6) => '     a *c'."
+        "test_file.peg: Expected 'b' at position (3, 6) => '     a *c'."
     ) == str(e.value)
     assert (e.value.line, e.value.col) == (3, 6)
 

--- a/arpeggio/tests/test_error_reporting_verbose.py
+++ b/arpeggio/tests/test_error_reporting_verbose.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#######################################################################
+# Name: test_error_reporting_verbose
+# Purpose: Test error reporting for various cases when verbose=True enabled.
+# Author: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+# Copyright: (c) 2015 Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+# License: MIT License
+#######################################################################
+from __future__ import unicode_literals
+import pytest
+
+from arpeggio import Optional, Not, ParserPython, NoMatch, EOF, Sequence, RegExMatch, StrMatch, OrderedChoice
+from arpeggio import RegExMatch as _
+
+
+def test_optional_with_better_match():
+    """
+    Test that optional match that has gone further in the input stream
+    has precedence over non-optional.
+    """
+
+    def grammar():  return [first, (Optional(second), 'six')]
+    def first():    return 'one', 'two', 'three', '4'
+    def second():   return 'one', 'two', 'three', 'four', 'five'
+
+    parser = ParserPython(grammar, verbose=True)
+    assert parser.verbose
+
+    with pytest.raises(NoMatch) as e:
+        parser.parse('one two three four 5')
+
+    assert (
+        "Expected "
+        "'six' at position (1, 1) or "
+        "'4' at position (1, 15) or "
+        "'five' at position (1, 20) => "
+        "'hree four *5'."
+    ) == str(e.value)
+    assert (e.value.line, e.value.col) == (1, 20)

--- a/arpeggio/tests/test_error_reporting_verbose2.py
+++ b/arpeggio/tests/test_error_reporting_verbose2.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#######################################################################
+# Name: test_error_reporting_verbose
+# Purpose: Test error reporting for various cases when verbose=True enabled.
+# Author: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+# Copyright: (c) 2015 Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+# License: MIT License
+#######################################################################
+from __future__ import unicode_literals
+import pytest
+
+from arpeggio import Optional, Not, ParserPython, NoMatch, EOF, Sequence, \
+    RegExMatch, StrMatch, OrderedChoice, UnorderedGroup, ZeroOrMore, OneOrMore
+from arpeggio import RegExMatch as _
+
+
+def test_ordered_choice():
+    def grammar():
+        return ["a", "b", "c"], EOF
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("ab")
+    assert (
+       "Expected:\n"
+       "1:1: 'b' or 'c'\n"
+       "1:2: EOF\n"
+       " => 'a*b'."
+    ) == str(e.value)
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("bb")
+    assert (
+       "Expected:\n"
+       "1:1: 'a' or 'c'\n"
+       "1:2: EOF\n"
+       " => 'b*b'."
+    ) == str(e.value)
+
+
+def test_unordered_group_with_optionals_and_separator():
+    def grammar():
+        return UnorderedGroup("a", Optional("b"), "c", sep=","), EOF
+
+    parser = ParserPython(grammar)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a, c, ")
+    assert (
+       "Expected 'b' at position (1, 7) => 'a, c, *'."
+    ) == str(e.value)
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a, c, ")
+    assert (
+       "Expected:\n"
+       "1:5: EOF\n"
+       "1:7: 'b'\n"
+       " => 'a, c, *'."
+    ) == str(e.value)
+
+
+def test_zero_or_more_with_separator():
+    def grammar():
+        return ZeroOrMore("a", sep=","), EOF
+
+    parser = ParserPython(grammar)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a,a ,a,")
+    assert (
+       "Expected 'a' at position (1, 8) => 'a,a ,a,*'."
+    ) == str(e.value)
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a,a ,a,")
+    assert (
+       "Expected:\n"
+       "1:7: EOF\n"
+       "1:8: 'a'\n"
+       " => 'a,a ,a,*'."
+    ) == str(e.value)
+
+
+def test_zero_or_more_with_optional_separator():
+    def grammar():
+        return ZeroOrMore("a", sep=RegExMatch(",?")), EOF
+
+    parser = ParserPython(grammar)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a,a ,a,")
+    assert (
+       "Expected 'a' at position (1, 8) => 'a,a ,a,*'."
+    ) == str(e.value)
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a,a ,a,")
+    assert (
+       "Expected:\n"
+       "1:7: EOF\n"
+       "1:8: 'a'\n"
+       " => 'a,a ,a,*'."
+    ) == str(e.value)
+
+
+def test_one_or_more_with_optional_separator():
+    def grammar():
+        return OneOrMore("a", sep=RegExMatch(",?")), "b"
+
+    parser = ParserPython(grammar)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a a, b")
+    assert (
+        "Expected 'a' at position (1, 6) => 'a a, *b'."
+    ) == str(e.value)
+
+    parser = ParserPython(grammar, verbose2=True)
+    with pytest.raises(NoMatch) as e:
+        parser.parse("a a, b")
+    assert (
+        "Expected:\n"
+        "1:4: 'b'\n"
+        "1:6: 'a'\n"
+        " => 'a a, *b'."
+    ) == str(e.value)


### PR DESCRIPTION
The `verbose=False/True` option is added to the Parser class. This option is disabled by default, and the existing behavior is fully preserved.

When the option is enabled, the final expected message is extended with extra information about the previously "weakly failed" rules. This way, not only the last failed NoMatch exception and its failing rules are displayed but also all the rules that were not matched during the whole parsing process.

Open points:

- [x] ~~The markers could be removed, and **all** nodes could be printed when `verbose=True`.~~ Implemented by `verbose2`.
- [ ] The reporting code is extremely messy and needs a cleanup.
- [ ] `verbose` may be not the best name for this option. I am happy to change it to any other name.

----

**Will be done after/if the approach is confirmed.**

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
