### PR TITLE
Remove use pytest-runner

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
 packages = find:
 include_package_data = True
 setup_requires =
-    pytest-runner
     wheel
 tests_require = pytest
 


### PR DESCRIPTION
Acording to my conversation with `pytest-runner` maintainer this module should be no longer used.
Maintainer added about that "Deprecation Notice" on https://github.com/pytest-dev/pytest-runner

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
