### PR TITLE
Fix PEG parsers' "comment" rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ please take a look at related PRs and issues and see if the change affects you.
 - fix: #98 suppressed match in zero-or-more [#98]. Thanks @vpavlu for reporting
   the issue.
 
+- fix: empty comments in .peg files hid the next line, commented or not.
+
 [#101]: https://github.com/textX/Arpeggio/issues/101
 [#98]: https://github.com/textX/Arpeggio/issues/98
 [#96]: https://github.com/textX/Arpeggio/issues/96

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -58,7 +58,7 @@ def rule_name():        return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
 def rule_crossref():    return rule_name
 def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
                                  r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
-def comment():          return "//", _(".*\n")
+def comment():          return _("//.*\n", multiline=False)
 
 
 class ParserPEG(ParserPEGOrig):

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -67,8 +67,8 @@ def regex():            return [("r'", _(r'''[^'\\]*(?:\\.[^'\\]*)*'''), "'"),
 def rule_name():        return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
 def rule_crossref():    return rule_name
 def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
-                                 r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
-def comment():          return "//", _(".*\n")
+                                     r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
+def comment():          return _("//.*\n", multiline=False)
 
 
 # Escape sequences supported in PEG literal string matches

--- a/arpeggio/tests/test_peg_parser.py
+++ b/arpeggio/tests/test_peg_parser.py
@@ -16,6 +16,7 @@ grammar = r'''
     factor <- ("+" / "-")?
               (number / "(" expression ")");
     // This is another comment
+    //
     term <- factor (( "*" / "/") factor)*;
     expression <- term (("+" / "-") term)*;
     calc <- expression+ EOF;


### PR DESCRIPTION
The problem with the previous version was that if there is no text after the '//', regular whitespace processing kicked in and the regexp was applied to the next non-empty line.

The effect of this was that the next line gets commented off unconditionally, which is kindof not what you want.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
