### PR TITLE
The state system and support for the actions and states in the PEG parser notation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,8 @@
 Arpeggio - Parser interpreter based on PEG grammars
 
-Author: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+Arpeggio author: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+
+Original author of the state and actions subsystems: Andrey N. Dotsenko <pgandrey@ya.ru>
 
 
 # Contributors

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -923,17 +923,21 @@ class Kwd(StrMatch):
         self.rule_name = 'keyword'
 
 
-class MatchAction(ParsingExpression):
-    action_name: str
+class MatchActions(ParsingExpression):
+    actions: list[list[str]]
 
-    def __init__(self, rule, action):
+    def __init__(self, rule, actions):
         super().__init__(rule_name='', nodes=[rule])
-        self.action_name = action
+        self.actions = actions
 
     def _parse(self, parser):
         rule_node = self.nodes[0]
-        action = getattr(parser.actions, self.action_name)
-        retval = action(rule_node)
+        c_pos = parser.position
+        retval = rule_node.parse(parser)
+        for action in self.actions:
+            action_name = action[0]
+            action_method = getattr(parser.actions, action_name)
+            retval = action_method(rule_node, retval, c_pos, args=action[1:])
         return retval
 
     def __str__(self):

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -952,11 +952,11 @@ class Kwd(StrMatch):
 class MatchActions(ParsingExpression):
     actions: list[list[str]]
 
-    def __init__(self, rule, actions):
+    def __init__(self, rule: ParsingExpression, actions: list[list[str]]):
         super().__init__(rule_name='', nodes=[rule])
         self.actions = actions
 
-    def _parse(self, parser):
+    def _parse(self, parser: 'Parser'):
         rule_node = self.nodes[0]
         c_pos = parser.position
         retval = rule_node.parse(parser)
@@ -982,11 +982,15 @@ class MatchActions(ParsingExpression):
 class MatchState(ParsingExpression):
     state_name: str
 
-    def __init__(self, rule, state_name: str):
+    def __init__(
+        self,
+        rule: ParsingExpression,
+        state_name: str,
+    ):
         super().__init__(rule_name='', nodes=[rule])
         self.state_name = state_name
 
-    def _parse(self, parser):
+    def _parse(self, parser: 'Parser'):
         parser_state = parser.state
         states_stack = parser_state.states_stack
 
@@ -1480,10 +1484,12 @@ class SemanticActionToString(SemanticAction):
 
 
 class ParserState:
+    _parser: 'Parser'
+
     def __init__(self, parser):
         self._parser = parser
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict = None):
         return self.__class__(self._parser)
 
 

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -419,6 +419,10 @@ class ParsingExpression(ParsingStatement):
             self.nodes[i] = resolve_cb(node)
         return super().resolve(resolve_cb)
 
+    @property
+    def resolved_rule_name(self):
+        return self.rule_name
+
     @abc.abstractmethod
     def _parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         pass

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -665,13 +665,20 @@ class And(SyntaxPredicate):
     """
     def _parse(self, parser):
         c_pos = parser.position
-        for e in self.nodes:
-            try:
-                e.parse(parser)
-            except NoMatch:
-                parser.position = c_pos
-                raise
-        parser.position = c_pos
+        memo = {}
+        saved_state = copy.deepcopy(parser.state, memo)
+
+        try:
+            for e in self.nodes:
+                try:
+                    e.parse(parser)
+                except NoMatch:
+                    parser.position = c_pos
+                    raise
+            parser.position = c_pos
+        finally:
+            parser.state = saved_state
+
 
 
 class Not(SyntaxPredicate):
@@ -682,6 +689,7 @@ class Not(SyntaxPredicate):
     def _parse(self, parser):
         c_pos = parser.position
         old_in_not = parser.in_not
+
         parser.in_not = True
         try:
             for e in self.nodes:

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -1591,6 +1591,11 @@ class ParserState:
         copied.state_layers = copy.deepcopy(self.state_layers, memo)
         return copied
 
+    def load_from(self, other_state: 'ParserState'):
+        self.state_layers = other_state.state_layers
+        # Make the other state invalid to prevent possible errors:
+        other_state.state_layers = []
+
     def push_parsing_state(self, parsing_state: ParsingState):
         self.state_layers[-1].states_stack.append(parsing_state)
 
@@ -1969,7 +1974,7 @@ class Parser(DebugPrinter):
         return copy.deepcopy(self._state)
 
     def load_state(self, new_state: ParserState):
-        self._state = new_state
+        self._state.load_from(new_state)
 
 
 class CrossRef(ParserModelItem):

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -360,6 +360,10 @@ class ParsingExpression(ParserModelItem):
             self.nodes[i] = resolve_cb(node)
         return super().resolve(resolve_cb)
 
+    @abc.abstractmethod
+    def _parse(self, parser: 'Parser'):
+        pass
+
 
 class Sequence(ParsingExpression):
     """
@@ -371,6 +375,7 @@ class Sequence(ParsingExpression):
         self.ws = kwargs.pop('ws', None)
         self.skipws = kwargs.pop('skipws', None)
 
+    @typing.override
     def _parse(self, parser):
         results = []
         c_pos = parser.position
@@ -415,6 +420,7 @@ class OrderedChoice(Sequence):
     Will match one of the parser expressions specified. Parser will try to
     match expressions in the order they are defined.
     """
+    @typing.override
     def _parse(self, parser):
         result = None
         match = False
@@ -472,6 +478,7 @@ class Optional(Repetition):
     Optional will try to match parser expression specified and will not fail
     in case match is not successful.
     """
+    @typing.override
     def _parse(self, parser):
         result = None
         c_pos = parser.position
@@ -489,6 +496,7 @@ class ZeroOrMore(Repetition):
     ZeroOrMore will try to match parser expression specified zero or more
     times. It will never fail.
     """
+    @typing.override
     def _parse(self, parser):
         results = []
 
@@ -532,6 +540,7 @@ class OneOrMore(Repetition):
     """
     OneOrMore will try to match parser expression specified one or more times.
     """
+    @typing.override
     def _parse(self, parser):
         results = []
         first = True
@@ -582,6 +591,7 @@ class UnorderedGroup(Repetition):
     """
     Will try to match all the parsing expressions in any order.
     """
+    @typing.override
     def _parse(self, parser):
         results = []
         c_pos = parser.position
@@ -676,6 +686,7 @@ class And(SyntaxPredicate):
     This predicate will succeed if the specified expression matches current
     input.
     """
+    @typing.override
     def _parse(self, parser):
         c_pos = parser.position
         memo = {}
@@ -699,6 +710,7 @@ class Not(SyntaxPredicate):
     This predicate will succeed if the specified expression doesn't match
     current input.
     """
+    @typing.override
     def _parse(self, parser):
         c_pos = parser.position
         old_in_not = parser.in_not
@@ -721,6 +733,7 @@ class Empty(SyntaxPredicate):
     """
     This predicate will always succeed without consuming input.
     """
+    @typing.override
     def _parse(self, parser):
         pass
 
@@ -740,6 +753,7 @@ class Combine(Decorator):
     This rules will always return a Terminal parse tree node.
     Whitespaces will be preserved. Comments will not be matched.
     """
+    @typing.override
     def _parse(self, parser):
         results = []
 
@@ -885,6 +899,7 @@ class RegExMatch(Match):
     def __unicode__(self):
         return self.__str__()
 
+    @typing.override
     def _parse(self, parser):
         c_pos = parser.position
         m = self.regex.match(parser.input, c_pos)
@@ -918,6 +933,7 @@ class StrMatch(Match):
         self.to_match = to_match
         self.ignore_case = ignore_case
 
+    @typing.override
     def _parse(self, parser):
         c_pos = parser.position
         input_frag = parser.input[c_pos:c_pos+len(self.to_match)]
@@ -993,6 +1009,7 @@ class MatchState(ParsingExpression):
         super().__init__(rule_name='', nodes=[rule])
         self._parsing_state = parsing_state
 
+    @typing.override
     def _parse(self, parser: 'Parser'):
         parser_state = parser.state
         states_stack = parser_state.states_stack
@@ -1046,6 +1063,7 @@ class EndOfFile(Match):
     def name(self):
         return "EOF"
 
+    @typing.override
     def _parse(self, parser):
         c_pos = parser.position
         if len(parser.input) == c_pos:

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -564,6 +564,13 @@ class ZeroOrMore(Repetition):
 
         return results
 
+    @typing.override
+    def resolve(self, resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]) -> ParserModelItem:
+        node = super().resolve(resolve_cb)
+        if node.sep:
+            node.sep = node.sep.resolve(resolve_cb)
+        return node
+
 
 class OneOrMore(Repetition):
     """
@@ -619,6 +626,13 @@ class OneOrMore(Repetition):
             parser.state.pop_repetition_layer()
 
         return results
+
+    @typing.override
+    def resolve(self, resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]) -> ParserModelItem:
+        node = super().resolve(resolve_cb)
+        if node.sep:
+            node.sep = node.sep.resolve(resolve_cb)
+        return node
 
 
 class UnorderedGroup(Repetition):
@@ -2433,6 +2447,9 @@ class ParserPython(Parser):
                 retval.nodes = [inner_from_python(e) for e in expression]
                 if any(isinstance(x, CrossRef) for x in retval.nodes):
                     __for_resolving.append(retval)
+
+            elif isinstance(expression, ParserModelItem):
+                retval = expression
 
             else:
                 raise GrammarError(f"Unrecognized grammar element '{expression}'.")

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -2255,12 +2255,6 @@ class Parser(DebugPrinter):
     def state(self) -> _state_class:
         return self._state
 
-    def save_state(self) -> ParserState:
-        return copy.deepcopy(self._state)
-
-    def load_state(self, new_state: ParserState):
-        self._state.load_from(new_state)
-
     def take_state_snapshot(self) -> ParserStateSnapshot:
         """
         Take a snapshot of the parser state.

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -384,7 +384,7 @@ class ParsingExpression(ParsingStatement):
         return result
 
     def resolve(self, resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]) -> ParserModelItem:
-        for i, node in enumerate(self.nodes):
+        for i, node in enumerate(typing.cast(list[ParsingExpression], self.nodes)):
             self.nodes[i] = resolve_cb(node)
         return super().resolve(resolve_cb)
 

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -970,14 +970,21 @@ class MatchActions(ParsingExpression):
         rule_node = self.nodes[0]
         return str(rule_node)
 
+    @property
+    def desc(self):
+        return "{}{{{}}}{}".format(
+            self.name,
+            ', '.join(map(lambda x: ' '.join(x), self.actions)),
+            "-" if self.suppress else "",
+        )
 
-class MatchState(Match):
+
+class MatchState(ParsingExpression):
     state_name: str
 
     def __init__(self, rule, state_name: str):
         super().__init__(rule_name='', nodes=[rule])
         self.state_name = state_name
-        self.to_match = f'[{state_name}]{str(rule)}'
 
     def _parse(self, parser):
         parser_state = parser.state
@@ -1007,6 +1014,14 @@ class MatchState(Match):
     def __str__(self):
         rule_node = self.nodes[0]
         return str(rule_node)
+
+    @property
+    def desc(self):
+        return "{}({}){}".format(
+            self.name,
+            self.state_name,
+            "-" if self.suppress else "",
+        )
 
 
 class EndOfFile(Match):

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -1135,7 +1135,7 @@ class PopState(ParsingStateStatement):
         )
 
 
-class WrappedWithStateLayer(ParsingExpression):
+class StateWrapper(ParsingExpression):
     """
     An expression wrapper that wraps an expression with a separate state layer.
 

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -170,7 +170,10 @@ class ParserModelItem(abc.ABC):
     including any helper classes.
     """
 
-    def resolve(self, resolve_cb: typing.Callable[['ParserModelItem'], 'ParserModelItem']):
+    def resolve(
+        self,
+        resolve_cb: typing.Callable[['ParserModelItem'], 'ParserModelItem']
+    ) -> 'ParserModelItem':
         resolved_node = resolve_cb(self)
         return resolved_node
 
@@ -186,7 +189,7 @@ class ParsingStatement(ParserModelItem):
     """
 
     @abc.abstractmethod
-    def parse(self, parser: 'Parser'):
+    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
         pass
 
 
@@ -379,13 +382,13 @@ class ParsingExpression(ParsingStatement):
 
         return result
 
-    def resolve(self, resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]):
+    def resolve(self, resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]) -> ParserModelItem:
         for i, node in enumerate(self.nodes):
             self.nodes[i] = resolve_cb(node)
         return super().resolve(resolve_cb)
 
     @abc.abstractmethod
-    def _parse(self, parser: 'Parser'):
+    def _parse(self, parser: 'Parser') -> 'ParseTreeNode':
         pass
 
 
@@ -1053,7 +1056,7 @@ class MatchState(ParsingStateStatement):
 
     If the current state doesn't match the expected state then the parsing process will fail.
     """
-    def parse(self, parser: 'Parser'):
+    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
         c_pos = parser.position
         curr_parsing_state = parser.state.parsing_state
         if not curr_parsing_state:
@@ -1088,7 +1091,7 @@ class PushState(ParsingStateStatement):
 
     This statement always passes.
     """
-    def parse(self, parser: 'Parser'):
+    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
         parser.state.push_parsing_state(self._parsing_state)
         return None
 
@@ -1109,7 +1112,7 @@ class PopState(ParsingStateStatement):
     If the current statement doesn't match the expected statement, then the parsing process will fail. Otherwise,
     the current parsing state will be removed from the top of the parsing states stack.
     """
-    def parse(self, parser: 'Parser'):
+    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
         curr_parsing_state = parser.state.parsing_state
         if curr_parsing_state != self._parsing_state:
             c_pos = parser.position
@@ -1143,7 +1146,7 @@ class WrappedWithStateLayer(ParsingExpression):
         super().__init__(nodes=[node])
 
     @typing.override
-    def _parse(self, parser: 'Parser'):
+    def _parse(self, parser: 'Parser') -> 'ParseTreeNode':
         saved_state = parser.save_state()
 
         parser.state.push_state_layer()
@@ -1657,11 +1660,11 @@ class ParserState:
     def push_parsing_state(self, parsing_state: ParsingState):
         self.state_layers[-1].states_stack.append(parsing_state)
 
-    def pop_parsing_state(self):
+    def pop_parsing_state(self) -> ParsingState:
         return self.state_layers[-1].states_stack.pop()
 
     @property
-    def parsing_state(self):
+    def parsing_state(self) -> ParsingState | None:
         parsing_state = None
         for state_layer in reversed(self.state_layers):
             if state_layer.states_stack:
@@ -1672,7 +1675,7 @@ class ParserState:
     def push_state_layer(self):
         self.state_layers.append(self._state_layer_class())
 
-    def pop_state_layer(self):
+    def pop_state_layer(self) -> ParserStateLayer:
         return self.state_layers.pop()
 
 

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -2221,7 +2221,7 @@ class Parser(DebugPrinter):
 
         return retval.replace('\n', ' ').replace('\r', '')
 
-    def _nm_raise(self, *args):
+    def _nm_raise(self, *args) -> typing.NoReturn:
         """
         Register new NoMatch object if the input is consumed
         from the last NoMatch and raise last NoMatch.

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -949,36 +949,6 @@ class Kwd(StrMatch):
         self.rule_name = 'keyword'
 
 
-class MatchActions(ParsingExpression):
-    actions: list[list[str]]
-
-    def __init__(self, rule: ParsingExpression, actions: list[list[str]]):
-        super().__init__(rule_name='', nodes=[rule])
-        self.actions = actions
-
-    def _parse(self, parser: 'Parser'):
-        rule_node = self.nodes[0]
-        c_pos = parser.position
-        retval = rule_node.parse(parser)
-        for action in self.actions:
-            action_name = action[0]
-            action_method = getattr(parser.actions, action_name)
-            retval = action_method(rule_node, retval, c_pos, args=action[1:])
-        return retval
-
-    def __str__(self):
-        rule_node = self.nodes[0]
-        return str(rule_node)
-
-    @property
-    def desc(self):
-        return "{}{{{}}}{}".format(
-            self.name,
-            ', '.join(map(lambda x: ' '.join(x), self.actions)),
-            "-" if self.suppress else "",
-        )
-
-
 class MatchState(ParsingExpression):
     state_name: str
 

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -1,8 +1,9 @@
 ###############################################################################
 # Name: arpeggio.py
 # Purpose: PEG parser interpreter
-# Author: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
-# Copyright: (c) 2009-2019 Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>
+# Author: Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@ya.ru>
+# Copyright: (c) 2009-2017 Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>
+# Copyright: (c) 2025 Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@ya.ru>
 # License: MIT License
 #
 # This is an implementation of packrat parser interpreter based on PEG
@@ -920,6 +921,24 @@ class Kwd(StrMatch):
         self.to_match = to_match
         self.root = True
         self.rule_name = 'keyword'
+
+
+class MatchAction(ParsingExpression):
+    action_name: str
+
+    def __init__(self, rule, action):
+        super().__init__(rule_name='', nodes=[rule])
+        self.action_name = action
+
+    def _parse(self, parser):
+        rule_node = self.nodes[0]
+        action = getattr(parser.actions, self.action_name)
+        retval = action(rule_node)
+        return retval
+
+    def __str__(self):
+        rule_node = self.nodes[0]
+        return str(rule_node)
 
 
 class EndOfFile(Match):

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -190,7 +190,7 @@ class ParsingStatement(ParserModelItem):
     """
 
     @abc.abstractmethod
-    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         pass
 
 
@@ -389,7 +389,7 @@ class ParsingExpression(ParsingStatement):
         return super().resolve(resolve_cb)
 
     @abc.abstractmethod
-    def _parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def _parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         pass
 
 
@@ -1085,7 +1085,7 @@ class MatchState(ParsingStateStatement):
 
     If the current state doesn't match the expected state then the parsing process will fail.
     """
-    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         c_pos = parser.position
         curr_parsing_state = parser.state.parsing_state
         if not curr_parsing_state:
@@ -1120,7 +1120,7 @@ class PushState(ParsingStateStatement):
 
     This statement always passes.
     """
-    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         parser.state.push_parsing_state(self._parsing_state)
         return None
 
@@ -1141,7 +1141,7 @@ class PopState(ParsingStateStatement):
     If the current statement doesn't match the expected statement, then the parsing process will fail. Otherwise,
     the current parsing state will be removed from the top of the parsing states stack.
     """
-    def parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         curr_parsing_state = parser.state.parsing_state
         if curr_parsing_state != self._parsing_state:
             c_pos = parser.position
@@ -1175,7 +1175,7 @@ class StateWrapper(ParsingExpression):
         super().__init__(nodes=[node])
 
     @typing.override
-    def _parse(self, parser: 'Parser') -> 'ParseTreeNode':
+    def _parse(self, parser: 'Parser') -> typing.Optional['ParseTreeNode']:
         state_snapshot = parser.take_state_snapshot()
 
         parser.state.push_state_layer()

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -74,7 +74,6 @@ class NoMatch(Exception):
         self.position = position
         self.parser = parser
 
-
     def eval_attrs(self):
         """
         Call this to evaluate `message`, `context`, `line` and `col`. Called by __str__.
@@ -704,7 +703,6 @@ class And(SyntaxPredicate):
             parser.load_state(saved_state)
 
 
-
 class Not(SyntaxPredicate):
     """
     This predicate will succeed if the specified expression doesn't match
@@ -972,7 +970,6 @@ class StrMatch(Match):
         return hash(self.to_match)
 
 
-
 # HACK: Kwd class is a bit hackish. Need to find a better way to
 #       introduce different classes of string tokens.
 class Kwd(StrMatch):
@@ -1126,7 +1123,7 @@ class WrappedWithStateLayer(ParsingExpression):
         try:
             retval = self.nodes[0].parse(parser)
             parser.state.pop_state_layer()
-        except:
+        except Exception:
             parser.load_state(saved_state)
             raise
 
@@ -1599,7 +1596,6 @@ class ParserStateLayer:
     def __deepcopy__(self, memo: dict = None):
         copied = self.__class__()
         return copied
-
 
 
 class ParserState:

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -2025,7 +2025,7 @@ class Parser(DebugPrinter):
             self.comments_model._clear_cache()
 
     @property
-    def state(self) -> ParserState:
+    def state(self) -> _state_class:
         return self._state
 
     def save_state(self) -> ParserState:

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -1062,15 +1062,15 @@ class MatchState(ParsingStateStatement):
         if not curr_parsing_state:
             if parser.debug:
                 parser.dprint(
-                    f"-- The states stack is empty while matching `{self.state_name}` state at {c_pos} => "
+                    f"-- The states stack is empty while matching `{self.parsing_state}` state at {c_pos} => "
                     f"'{parser.context()}'")
             parser._nm_raise(self, c_pos, parser)
 
         if curr_parsing_state != self._parsing_state:
             if parser.debug:
                 parser.dprint(
-                    f"-- The current state (`{curr_parsing_state}`) doesn't match `{self.parsing_state}` state at {c_pos} => "
-                    f"'{parser.context()}'")
+                    f"-- The current state (`{curr_parsing_state}`) doesn't match `{self.parsing_state}` state"
+                    f" at {c_pos} => '{parser.context()}'")
             parser._nm_raise(self, c_pos, parser)
 
         return None
@@ -1118,8 +1118,8 @@ class PopState(ParsingStateStatement):
             c_pos = parser.position
             if parser.debug:
                 parser.dprint(
-                    f"-- The current state (`{curr_parsing_state}`) doesn't match `{self.parsing_state}` state at {c_pos} => "
-                    f"'{parser.context()}'")
+                    f"-- The current state (`{curr_parsing_state}`) doesn't match `{self.parsing_state}` state"
+                    f" at {c_pos} => '{parser.context()}'")
             parser._nm_raise(self, c_pos, parser)
 
         parser.state.pop_parsing_state()

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -31,7 +31,7 @@ ASSIGNMENT = "="
 ORDERED_CHOICE = "/"
 ZERO_OR_MORE = "*"
 ONE_OR_MORE_SYMBOL = '+'
-ONE_OR_MORE = _('(?<!\s)\\' + ONE_OR_MORE_SYMBOL)
+ONE_OR_MORE = _('(?<!\\s)\\' + ONE_OR_MORE_SYMBOL)
 OPTIONAL = "?"
 UNORDERED_GROUP = "#"
 AND = "&"
@@ -49,42 +49,104 @@ POP_STATE = '-@'
 STATE_LAYER_START = '@('
 STATE_LAYER_END = ')'
 
-# PEG syntax rules
-def peggrammar():       return OneOrMore(rule), EOF
-def rule():             return rule_name, ASSIGNMENT, ordered_choice
-def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
-def sequence():         return OneOrMore(full_expression)
-def operation():        return rule_crossref, calls
-def full_expression():  return Optional([AND, NOT]), repeated_expression
-def repeated_expression():      return expression, Optional([OPTIONAL,
-                                                             ZERO_OR_MORE,
-                                                             ONE_OR_MORE,
-                                                             UNORDERED_GROUP])
-def expression():       return [regex,
-                                push_state, pop_state, wrapped_with_state_layer, state,
-                                operation, rule_crossref,
-                                (OPEN, ordered_choice, CLOSE),
-                                str_match], Not(ASSIGNMENT)
 
-def state():            return STATE, state_name
-def push_state():       return PUSH_STATE, state_name
-def pop_state():        return POP_STATE, state_name
-def wrapped_with_state_layer(): return STATE_LAYER_START, ordered_choice, STATE_LAYER_END
+# PEG syntax rules
+def peggrammar():
+    return OneOrMore(rule), EOF
+
+
+def rule():
+    return rule_name, ASSIGNMENT, ordered_choice
+
+
+def ordered_choice():
+    return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
+
+
+def sequence():
+    return OneOrMore(full_expression)
+
+
+def operation():
+    return rule_crossref, calls
+
+
+def full_expression():
+    return Optional([AND, NOT]), repeated_expression
+
+
+def repeated_expression():
+    return expression, Optional([
+        OPTIONAL,
+        ZERO_OR_MORE,
+        ONE_OR_MORE,
+        UNORDERED_GROUP
+    ])
+
+
+def expression():
+    return [
+        regex,
+        push_state, pop_state, wrapped_with_state_layer, state,
+        operation, rule_crossref,
+        (OPEN, ordered_choice, CLOSE),
+        str_match
+    ], Not(ASSIGNMENT)
+
+
+def state():
+    return STATE, state_name
+
+
+def push_state():
+    return PUSH_STATE, state_name
+
+
+def pop_state():
+    return POP_STATE, state_name
+
+
+def wrapped_with_state_layer():
+    return STATE_LAYER_START, ordered_choice, STATE_LAYER_END
+
 
 # PEG Lexical rules
-def regex():            return _(r"""(r'[^'\\]*(?:\\.[^'\\]*)*')|"""
-                                 r'''(r"[^"\\]*(?:\\.[^"\\]*)*")''')
-def rule_name():        return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
-def rule_crossref():    return rule_name
-def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
-                                 r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
-def comment():          return _("//.*\n", multiline=False)
+def regex():
+    return _(r"""(r'[^'\\]*(?:\\.[^'\\]*)*')|"""
+             r'''(r"[^"\\]*(?:\\.[^"\\]*)*")''')
 
-def calls():            return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
-def call():             return OneOrMore(call_argument)
-def call_argument():    return _(r'[^\} \t,]+')
 
-def state_name():       return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
+def rule_name():
+    return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
+
+
+def rule_crossref():
+    return rule_name
+
+
+def str_match():
+    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
+             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
+
+
+def comment():
+    return _("//.*\n", multiline=False)
+
+
+def calls():
+    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+
+
+def call():
+    return OneOrMore(call_argument)
+
+
+def call_argument():
+    return _(r'[^\} \t,]+')
+
+
+def state_name():
+    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
 class ParserPEG(ParserPEGOrig):

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -3,8 +3,9 @@
 # Purpose: This module is a variation of the original peg.py.
 #   The syntax is slightly changed to be more readable and familiar to
 #   python users. It is based on the Yash's suggestion - issue 11
-# Author: Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>
-# Copyright: (c) 2014-2017 Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>
+# Author: Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@ya.ru>
+# Copyright: (c) 2009-2017 Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>
+# Copyright: (c) 2025 Igor R. Dejanovic <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@ya.ru>
 # License: MIT License
 #######################################################################
 
@@ -36,12 +37,15 @@ AND = "&"
 NOT = "!"
 OPEN = "("
 CLOSE = ")"
+CALL_START = "{"
+CALL_END = "}"
 
 # PEG syntax rules
 def peggrammar():       return OneOrMore(rule), EOF
 def rule():             return rule_name, ASSIGNMENT, ordered_choice
 def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
-def sequence():         return OneOrMore(prefix)
+def sequence():         return OneOrMore([operation, prefix])
+def operation():        return rule_crossref, call
 def prefix():           return Optional([AND, NOT]), sufix
 def sufix():            return expression, Optional([OPTIONAL,
                                                      ZERO_OR_MORE,
@@ -59,6 +63,10 @@ def rule_crossref():    return rule_name
 def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
                                  r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
 def comment():          return _("//.*\n", multiline=False)
+
+def call():             return CALL_START, call_arguments, CALL_END
+def call_arguments():   return OneOrMore(call_argument)
+def call_argument():    return _(r'[^\} \t]+')
 
 
 class ParserPEG(ParserPEGOrig):

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -131,7 +131,11 @@ def action_call():
 
 
 def action_call_argument():
-    return _(r'\w+')
+    return [_(r'\w+'), action_call_quoted_argument]
+
+
+def action_call_quoted_argument():
+    return str_match()
 
 
 # PEG Lexical rules

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -67,10 +67,6 @@ def sequence():
     return OneOrMore(full_expression)
 
 
-def operation():
-    return rule_crossref, calls
-
-
 def full_expression():
     return Optional([AND, NOT]), repeated_expression
 
@@ -87,8 +83,12 @@ def repeated_expression():
 def expression():
     return [
         regex,
-        push_state, pop_state, wrapped_with_state_layer, state,
-        operation, rule_crossref,
+        state,
+        push_state,
+        pop_state,
+        wrapped_with_state_layer,
+        operation,
+        rule_crossref,
         (OPEN, ordered_choice, CLOSE),
         str_match
     ], Not(ASSIGNMENT)
@@ -106,8 +106,28 @@ def pop_state():
     return POP_STATE, state_name
 
 
+def state_name():
+    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
+
+
 def wrapped_with_state_layer():
     return STATE_LAYER_START, ordered_choice, STATE_LAYER_END
+
+
+def operation():
+    return rule_crossref, calls
+
+
+def calls():
+    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+
+
+def call():
+    return OneOrMore(call_argument)
+
+
+def call_argument():
+    return _(r'[^\} \t,]+')
 
 
 # PEG Lexical rules
@@ -131,22 +151,6 @@ def str_match():
 
 def comment():
     return _("//.*\n", multiline=False)
-
-
-def calls():
-    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
-
-
-def call():
-    return OneOrMore(call_argument)
-
-
-def call_argument():
-    return _(r'[^\} \t,]+')
-
-
-def state_name():
-    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
 class ParserPEG(ParserPEGOrig):

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -83,9 +83,9 @@ def repeated_expression():
 def expression():
     return [
         regex,
-        state,
-        push_state,
-        pop_state,
+        parsing_state,
+        push_parsing_state,
+        pop_parsing_state,
         wrapped_with_state_layer,
         operation,
         rule_crossref,
@@ -94,19 +94,19 @@ def expression():
     ], Not(ASSIGNMENT)
 
 
-def state():
-    return STATE, state_name
+def parsing_state():
+    return STATE, parsing_state_name
 
 
-def push_state():
-    return PUSH_STATE, state_name
+def push_parsing_state():
+    return PUSH_STATE, parsing_state_name
 
 
-def pop_state():
-    return POP_STATE, state_name
+def pop_parsing_state():
+    return POP_STATE, parsing_state_name
 
 
-def state_name():
+def parsing_state_name():
     return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
@@ -115,18 +115,18 @@ def wrapped_with_state_layer():
 
 
 def operation():
-    return rule_crossref, calls
+    return rule_crossref, action_calls
 
 
-def calls():
-    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+def action_calls():
+    return CALL_START, action_call, ZeroOrMore([CALL_DELIMITER, action_call]), CALL_END
 
 
-def call():
-    return OneOrMore(call_argument)
+def action_call():
+    return OneOrMore(action_call_argument)
 
 
-def call_argument():
+def action_call_argument():
     return _(r'[^\} \t,]+')
 
 

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -16,6 +16,7 @@ from arpeggio import (
     OneOrMore,
     Optional,
     ParserPython,
+    StrMatch,
     ZeroOrMore,
     visit_parse_tree,
 )
@@ -38,14 +39,14 @@ AND = "&"
 NOT = "!"
 OPEN = "("
 CLOSE = ")"
-CALL_START = "{"
-CALL_END = "}"
-CALL_DELIMITER = ','
-STATE = '@'
-PUSH_STATE = '+@'
-POP_STATE = '-@'
-STATE_LAYER_START = '@('
-STATE_LAYER_END = ')'
+CALL_START = StrMatch("{", suppress=True)
+CALL_END = StrMatch("}", suppress=True)
+CALL_DELIMITER = StrMatch(',', suppress=True)
+STATE = StrMatch('@', suppress=True)
+PUSH_STATE = StrMatch('+@', suppress=True)
+POP_STATE = StrMatch('-@', suppress=True)
+STATE_LAYER_START = StrMatch('@(', suppress=True)
+STATE_LAYER_END = StrMatch(')', suppress=True)
 
 
 # PEG syntax rules
@@ -122,7 +123,7 @@ def wrapped_with_state_layer():
 
 
 def action_calls():
-    return CALL_START, action_call, ZeroOrMore([CALL_DELIMITER, action_call]), CALL_END
+    return CALL_START, action_call, ZeroOrMore((CALL_DELIMITER, action_call)), CALL_END
 
 
 def action_call():
@@ -130,7 +131,7 @@ def action_call():
 
 
 def action_call_argument():
-    return _(r'[^\} \t,]+')
+    return _(r'\w+')
 
 
 # PEG Lexical rules

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -39,13 +39,14 @@ OPEN = "("
 CLOSE = ")"
 CALL_START = "{"
 CALL_END = "}"
+CALL_DELIMITER = ','
 
 # PEG syntax rules
 def peggrammar():       return OneOrMore(rule), EOF
 def rule():             return rule_name, ASSIGNMENT, ordered_choice
 def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
 def sequence():         return OneOrMore([operation, prefix])
-def operation():        return rule_crossref, call
+def operation():        return rule_crossref, calls
 def prefix():           return Optional([AND, NOT]), sufix
 def sufix():            return expression, Optional([OPTIONAL,
                                                      ZERO_OR_MORE,
@@ -64,9 +65,9 @@ def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
                                  r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
 def comment():          return _("//.*\n", multiline=False)
 
-def call():             return CALL_START, call_arguments, CALL_END
-def call_arguments():   return OneOrMore(call_argument)
-def call_argument():    return _(r'[^\} \t]+')
+def calls():            return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+def call():             return OneOrMore(call_argument)
+def call_argument():    return _(r'[^\} \t,]+')
 
 
 class ParserPEG(ParserPEGOrig):

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -37,8 +37,9 @@ OPTIONAL = "?"
 UNORDERED_GROUP = "#"
 AND = "&"
 NOT = "!"
-OPEN = "("
-CLOSE = ")"
+OPEN = StrMatch("(", suppress=True)
+REPETITION_DELIMITER = StrMatch("%", suppress=True)
+CLOSE = StrMatch(")", suppress=True)
 CALL_START = StrMatch("{", suppress=True)
 CALL_END = StrMatch("}", suppress=True)
 CALL_DELIMITER = StrMatch(',', suppress=True)
@@ -97,9 +98,29 @@ def parsing_expression():
         regex,
         str_match,
         (rule_crossref, Not(ASSIGNMENT)),
-        (OPEN, ordered_choice, CLOSE),
+        grouped_parsing_expression,
         wrapped_with_state_layer,
     ]
+
+
+def grouped_parsing_expression():
+    return (
+        OPEN,
+        ordered_choice,
+        [
+            (
+                REPETITION_DELIMITER,
+                ordered_choice,
+                CLOSE,
+                [
+                    ZERO_OR_MORE,
+                    ONE_OR_MORE,
+                ]
+            ),
+            ordered_choice,
+            CLOSE,
+        ]
+    )
 
 
 def parsing_state():

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -41,8 +41,6 @@ CLOSE = ")"
 CALL_START = "{"
 CALL_END = "}"
 CALL_DELIMITER = ','
-STATE_START = '['
-STATE_END = ']'
 STATE = '@'
 PUSH_STATE = '+@'
 POP_STATE = '-@'
@@ -121,10 +119,6 @@ def parsing_state_name():
 
 def wrapped_with_state_layer():
     return STATE_LAYER_START, ordered_choice, STATE_LAYER_END
-
-
-def operation():
-    return parsing_expression, action_calls
 
 
 def action_calls():

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -55,7 +55,7 @@ def repeated_expression():      return expression, Optional([OPTIONAL,
                                                              ZERO_OR_MORE,
                                                              ONE_OR_MORE,
                                                              UNORDERED_GROUP])
-def expression():       return [operation, regex, rule_crossref,
+def expression():       return [regex, operation, rule_crossref,
                                 (OPEN, ordered_choice, CLOSE),
                                 str_match], Not(ASSIGNMENT)
 

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -47,7 +47,7 @@ STATE_END = ']'
 def peggrammar():       return OneOrMore(rule), EOF
 def rule():             return rule_name, ASSIGNMENT, ordered_choice
 def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
-def sequence():         return OneOrMore([operation, full_expression])
+def sequence():         return OneOrMore(full_expression)
 def operation():        return rule_crossref, calls
 def full_expression():  return Optional([AND, NOT]), expression_with_state
 def expression_with_state():    return Optional(state), repeated_expression
@@ -55,7 +55,7 @@ def repeated_expression():      return expression, Optional([OPTIONAL,
                                                              ZERO_OR_MORE,
                                                              ONE_OR_MORE,
                                                              UNORDERED_GROUP])
-def expression():       return [regex, rule_crossref,
+def expression():       return [operation, regex, rule_crossref,
                                 (OPEN, ordered_choice, CLOSE),
                                 str_match], Not(ASSIGNMENT)
 

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -131,11 +131,12 @@ def action_call():
 
 
 def action_call_argument():
-    return [_(r'\w+'), action_call_quoted_argument]
+    return [_(r'\w+'), quoted_string]
 
 
-def action_call_quoted_argument():
-    return str_match()
+def quoted_string():
+    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
+             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
 
 
 # PEG Lexical rules
@@ -153,8 +154,7 @@ def rule_crossref():
 
 
 def str_match():
-    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
-             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
+    return quoted_string()
 
 
 def comment():

--- a/arpeggio/cleanpeg.py
+++ b/arpeggio/cleanpeg.py
@@ -72,7 +72,7 @@ def full_expression():
 
 
 def repeated_expression():
-    return expression, Optional([
+    return statement, Optional([
         OPTIONAL,
         ZERO_OR_MORE,
         ONE_OR_MORE,
@@ -80,18 +80,27 @@ def repeated_expression():
     ])
 
 
-def expression():
+def statement():
     return [
-        regex,
+        expression,
         parsing_state,
         push_parsing_state,
         pop_parsing_state,
-        wrapped_with_state_layer,
-        operation,
-        rule_crossref,
+    ]
+
+
+def expression():
+    return parsing_expression, Optional(action_calls)
+
+
+def parsing_expression():
+    return [
+        regex,
+        str_match,
+        (rule_crossref, Not(ASSIGNMENT)),
         (OPEN, ordered_choice, CLOSE),
-        str_match
-    ], Not(ASSIGNMENT)
+        wrapped_with_state_layer,
+    ]
 
 
 def parsing_state():
@@ -115,7 +124,7 @@ def wrapped_with_state_layer():
 
 
 def operation():
-    return rule_crossref, action_calls
+    return parsing_expression, action_calls
 
 
 def action_calls():

--- a/arpeggio/export.py
+++ b/arpeggio/export.py
@@ -114,7 +114,7 @@ class DOTExportAdapter(ExportAdapter):
 
 class PMDOTExportAdapter(DOTExportAdapter):
     """
-    Adapter for ParsingExpression graph types (parser model).
+    Adapter for ParsingStatement graph types (parser model).
     """
     @property
     def id(self):

--- a/arpeggio/export.py
+++ b/arpeggio/export.py
@@ -127,7 +127,7 @@ class PMDOTExportAdapter(DOTExportAdapter):
     @property
     def neighbours(self):
         if not hasattr(self, "_neighbours"):
-            if not isinstance(self, ParsingExpression):
+            if not isinstance(self.adaptee, ParsingExpression):
                 return []
 
             self._neighbours= []

--- a/arpeggio/export.py
+++ b/arpeggio/export.py
@@ -8,7 +8,10 @@
 
 import io
 
-from arpeggio import Terminal
+from arpeggio import (
+    Terminal,
+    ParsingExpression,
+)
 
 
 class Exporter:
@@ -124,6 +127,9 @@ class PMDOTExportAdapter(DOTExportAdapter):
     @property
     def neighbours(self):
         if not hasattr(self, "_neighbours"):
+            if not isinstance(self, ParsingExpression):
+                return []
+
             self._neighbours= []
 
             # Registry of adapters used in this export

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -606,6 +606,7 @@ class ActionFirstLonger(MatchedAction):
         else:
             matched_str = str(matched_result)
 
+        rule_name = self._rule.resolved_rule_name
         last_value = parser.state.repetition_last_rule_reference(rule_name)
         if last_value is None:
             parent_value = parser.state.repetition_last_rule_reference(rule_name, LayerScope.PARENT)
@@ -643,6 +644,7 @@ class ActionOtherSame(MatchedAction):
         else:
             matched_str = str(matched_result)
 
+        rule_name = self._rule.resolved_rule_name
         last_value = parser.state.repetition_last_rule_reference(rule_name)
         if matched_str != last_value:
             if parser.debug:

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -52,7 +52,7 @@ LEFT_ARROW = "<-"
 ORDERED_CHOICE = "/"
 ZERO_OR_MORE = "*"
 ONE_OR_MORE_SYMBOL = '+'
-ONE_OR_MORE = _('(?<!\s)\\' + ONE_OR_MORE_SYMBOL)
+ONE_OR_MORE = _('(?<!\\s)\\' + ONE_OR_MORE_SYMBOL)
 OPTIONAL = "?"
 UNORDERED_GROUP = "#"
 AND = "&"
@@ -71,45 +71,111 @@ STATE_LAYER_START = '@('
 STATE_LAYER_END = ')'
 
 
-
 # PEG syntax rules
-def peggrammar():       return OneOrMore(rule), EOF
-def rule():             return rule_name, LEFT_ARROW, ordered_choice, ";"
-def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
-def sequence():         return OneOrMore(full_expression)
-def operation():        return rule_crossref, calls
-def full_expression():  return Optional([AND, NOT]), repeated_expression
-def repeated_expression():      return expression, Optional([OPTIONAL,
-                                                             ZERO_OR_MORE,
-                                                             ONE_OR_MORE,
-                                                             UNORDERED_GROUP])
-def expression():       return [regex,
-                                push_state, pop_state, wrapped_with_state_layer, state,
-                                operation, rule_crossref,
-                                (OPEN, ordered_choice, CLOSE),
-                                str_match]
+def peggrammar():
+    return OneOrMore(rule), EOF
 
-def state():            return STATE, state_name
-def push_state():       return PUSH_STATE, state_name
-def pop_state():        return POP_STATE, state_name
-def wrapped_with_state_layer(): return (STATE_LAYER_START,
-                                        ordered_choice,
-                                        STATE_LAYER_END)
+
+def rule():
+    return rule_name, LEFT_ARROW, ordered_choice, ";"
+
+
+def ordered_choice():
+    return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
+
+
+def sequence():
+    return OneOrMore(full_expression)
+
+
+def operation():
+    return rule_crossref, calls
+
+
+def full_expression():
+    return Optional([AND, NOT]), repeated_expression
+
+
+def repeated_expression():
+    return expression, Optional([
+        OPTIONAL,
+        ZERO_OR_MORE,
+        ONE_OR_MORE,
+        UNORDERED_GROUP
+    ])
+
+
+def expression():
+    return [
+        regex,
+        push_state,
+        pop_state,
+        wrapped_with_state_layer,
+        state,
+        operation,
+        rule_crossref,
+        (OPEN, ordered_choice, CLOSE),
+        str_match,
+    ]
+
+
+def state():
+    return STATE, state_name
+
+
+def push_state():
+    return PUSH_STATE, state_name
+
+
+def pop_state():
+    return POP_STATE, state_name
+
+
+def wrapped_with_state_layer():
+    return (
+        STATE_LAYER_START,
+        ordered_choice,
+        STATE_LAYER_END
+    )
+
 
 # PEG Lexical rules
-def regex():            return _(r"""(r'[^'\\]*(?:\\.[^'\\]*)*')|"""
-                                 r'''(r"[^"\\]*(?:\\.[^"\\]*)*")''')
-def rule_name():        return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
-def rule_crossref():    return rule_name
-def str_match():        return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
-                                     r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
-def comment():          return _("//.*\n", multiline=False)
+def regex():
+    return _(r"""(r'[^'\\]*(?:\\.[^'\\]*)*')|"""
+             r'''(r"[^"\\]*(?:\\.[^"\\]*)*")''')
 
-def calls():            return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
-def call():             return OneOrMore(call_argument)
-def call_argument():    return _(r'[^\} \t,]+')
 
-def state_name():       return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
+def rule_name():
+    return _(r"[a-zA-Z_]([a-zA-Z_]|[0-9])*")
+
+
+def rule_crossref():
+    return rule_name
+
+
+def str_match():
+    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
+             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
+
+
+def comment():
+    return _("//.*\n", multiline=False)
+
+
+def calls():
+    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+
+
+def call():
+    return OneOrMore(call_argument)
+
+
+def call_argument():
+    return _(r'[^\} \t,]+')
+
+
+def state_name():
+    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
 # Escape sequences supported in PEG literal string matches
@@ -251,7 +317,11 @@ class ActionParentAdd(MatchedAction):
     ):
         parser_state = parser.state
         matched_str = str(matched_result)
-        parser_state.remember_rule_reference(self._rule.rule_name, matched_str, state_layer_scope=StateLayerScope.PARENT)
+        parser_state.remember_rule_reference(
+            self._rule.rule_name,
+            matched_str,
+            state_layer_scope = StateLayerScope.PARENT
+        )
         return matched_result
 
 
@@ -266,7 +336,11 @@ class ActionGlobalAdd(MatchedAction):
     ):
         parser_state = parser.state
         matched_str = str(matched_result)
-        parser_state.remember_rule_reference(self._rule.rule_name, matched_str, state_layer_scope=StateLayerScope.GLOBAL)
+        parser_state.remember_rule_reference(
+            self._rule.rule_name,
+            matched_str,
+            state_layer_scope = StateLayerScope.GLOBAL
+        )
         return matched_result
 
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -260,7 +260,6 @@ class MatchedAction(ParserModelDebuggable):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         """
         This method must be implemented to run an action over the match result.
@@ -305,7 +304,6 @@ class ActionPush(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         parser.state.push_rule_reference(self._rule.rule_name, str(matched_result))
         return matched_result
@@ -321,7 +319,6 @@ class ActionPop(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
@@ -353,7 +350,6 @@ class ActionListAppend(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''
@@ -375,7 +371,6 @@ class ActionListLast(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''
@@ -411,7 +406,6 @@ class ActionTryRemoveLast(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         parser.state.try_remove_last_rule_reference(self._rule.rule_name)
         return matched_result
@@ -438,7 +432,6 @@ class ActionLonger(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
@@ -478,7 +471,6 @@ class ActionPopFront(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
@@ -511,7 +503,6 @@ class ActionAdd(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(self._rule.rule_name, matched_str)
@@ -528,7 +519,6 @@ class ActionParentAdd(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
@@ -549,7 +539,6 @@ class ActionGlobalAdd(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
@@ -570,7 +559,6 @@ class ActionAny(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
 
@@ -595,7 +583,6 @@ class ActionSuppress(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         return None
 
@@ -612,7 +599,6 @@ class ActionFirstLonger(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''
@@ -650,7 +636,6 @@ class ActionOtherSame(MatchedAction):
         parser: 'ParserPEG',
         matched_result: ParseTreeNode | None,
         c_pos: int,
-        args: collections.abc.Sequence[typing.Any] = None,
     ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -25,7 +25,6 @@ from arpeggio import (
     HistorySequencePop,
     HistorySequencePopFront,
     HistorySetAdd,
-    HistorySetRemove,
     Not,
     OneOrMore,
     Optional,
@@ -48,7 +47,8 @@ from arpeggio import (
     PushState,
     PopState,
     StateWrapper,
-    ParsingState, ParserModelItem,
+    ParsingState,
+    ParserModelItem,
 )
 from arpeggio import RegExMatch as _
 
@@ -69,8 +69,6 @@ CLOSE = ")"
 CALL_START = "{"
 CALL_END = "}"
 CALL_DELIMITER = ','
-STATE_START = '['
-STATE_END = ']'
 STATE = '@'
 PUSH_STATE = '+@'
 POP_STATE = '-@'
@@ -153,10 +151,6 @@ def wrapped_with_state_layer():
         ordered_choice,
         STATE_LAYER_END
     )
-
-
-def operation():
-    return parsing_expression, action_calls
 
 
 def action_calls():

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -33,7 +33,7 @@ from arpeggio import (
     ParserStateLayer,
     ParserRepetitionStateLayer,
     Parser,
-    ParserModelDebuggable,
+    ParserModelDescribable,
     ParserPython,
     ParseTreeNode,
     PTNodeVisitor,
@@ -236,7 +236,7 @@ class LayerScope(enum.Enum):
     CURRENT = -1
 
 
-class MatchedAction(ParserModelDebuggable):
+class MatchedAction(ParserModelDescribable):
     """
     An abstract class for all action classes used in MatchActions parsing rules.
     """
@@ -282,6 +282,7 @@ class MatchedAction(ParserModelDebuggable):
     def __str__(self):
         return f'{str(self._rule)}{{{' '.join(map(str, self._args))}}}'
 
+    @typing.override
     @property
     def name(self):
         if self._command_hint:
@@ -679,6 +680,7 @@ class MatchActions(ParsingExpression):
         rule_node = self.nodes[0]
         return str(rule_node)
 
+    @typing.override
     @property
     def desc(self):
         return "{}{{{}}}{}".format(

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -232,10 +232,10 @@ class MatchedAction:
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         """
         This method must be implemented to run an action over the match result.
 
@@ -266,10 +266,10 @@ class ActionPush(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         parser.state.push_rule_reference(self._rule.rule_name, str(matched_result))
         return matched_result
 
@@ -282,10 +282,10 @@ class ActionPop(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
             removed = parser.state.pop_rule_reference(self._rule.rule_name, matched_str)
@@ -314,10 +314,10 @@ class ActionListAppend(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''
         else:
@@ -336,10 +336,10 @@ class ActionListLast(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         if matched_result is None:
             matched_str = ''
         else:
@@ -372,10 +372,10 @@ class ActionTryRemoveLast(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         parser.state.try_remove_last_rule_reference(self._rule.rule_name)
         return matched_result
 
@@ -399,10 +399,10 @@ class ActionLonger(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
             last = parser.state.last_rule_reference(self._rule.rule_name, self._state_scope)
@@ -439,10 +439,10 @@ class ActionPopFront(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         try:
             removed = parser.state.pop_front_rule_reference(self._rule.rule_name, matched_str)
@@ -472,10 +472,10 @@ class ActionAdd(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(self._rule.rule_name, matched_str)
         return matched_result
@@ -489,10 +489,10 @@ class ActionParentAdd(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
             self._rule.rule_name,
@@ -510,10 +510,10 @@ class ActionGlobalAdd(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
             self._rule.rule_name,
@@ -531,10 +531,10 @@ class ActionAny(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
 
         is_known = parser.state.rule_reference_is_known(self._rule.rule_name, matched_str)
@@ -556,10 +556,10 @@ class ActionSuppress(MatchedAction):
     def run(
         self,
         parser: 'ParserPEG',
-        matched_result: ParseTreeNode,
+        matched_result: ParseTreeNode | None,
         c_pos: int,
         args: collections.abc.Sequence[typing.Any] = None,
-    ) -> ParseTreeNode:
+    ) -> ParseTreeNode | None:
         return None
 
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -301,6 +301,27 @@ class ParserPEGActions:
         stack[rule.rule_name].pop()
         return matched_result
 
+    def pop_front(self, rule: Match, matched_result, c_pos, args=None):
+        stack = self._parser.state.rule_reference_stack
+        if not stack.get(rule.rule_name):
+            if self._parser.debug:
+                self._parser.dprint(
+                    f"-- The stack for `{rule.rule_name}` rule is empty at {c_pos} => "
+                    f"'{self._parser.context(len(str(matched_result)))}'")
+            self._parser._nm_raise(rule, c_pos, self._parser)
+
+        match_against = stack[rule.rule_name][0]
+
+        matched_str = str(matched_result)
+        if matched_str != match_against:
+            if self._parser.debug:
+                self._parser.dprint(
+                    f"-- No match '{match_against}' at {c_pos} => "
+                    f"'{self._parser.context(len(match_against))}'")
+            self._parser._nm_raise(rule, c_pos, self._parser)
+        stack[rule.rule_name].pop(0)
+        return matched_result
+
     def add(self, rule: Match, matched_result, c_pos, args=None):
         reference_set = self._parser.state.rule_reference_set
         reference_set.setdefault(rule.rule_name, set())

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -255,6 +255,21 @@ class ActionParentAdd(MatchedAction):
         return matched_result
 
 
+class ActionGlobalAdd(MatchedAction):
+    @typing.override
+    def run(
+        self,
+        parser: Parser,
+        matched_result: ParseTreeNode,
+        c_pos: int,
+        args = None,
+    ):
+        parser_state = parser.state
+        matched_str = str(matched_result)
+        parser_state.remember_rule_reference(self._rule.rule_name, matched_str, state_layer_scope=StateLayerScope.GLOBAL)
+        return matched_result
+
+
 class ActionAny(MatchedAction):
     @typing.override
     def run(
@@ -334,6 +349,7 @@ class PEGVisitor(PTNodeVisitor):
         'add': ActionAdd,
         'any': ActionAny,
         'parent_add': ActionParentAdd,
+        'global_add': ActionGlobalAdd,
     }
     matched_actions_aliases: dict[str, dict[str, str]] = {
         'state': {
@@ -342,6 +358,9 @@ class PEGVisitor(PTNodeVisitor):
         },
         'parent': {
             'add': 'parent_add',
+        },
+        'global': {
+            'add': 'global_add',
         },
     }
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -306,7 +306,7 @@ class ActionPush(MatchedAction):
         matched_result: ParseTreeNode | None,
         c_pos: int,
     ) -> ParseTreeNode | None:
-        parser.state.push_rule_reference(self._rule.rule_name, str(matched_result))
+        parser.state.push_rule_reference(self._rule.resolved_rule_name, str(matched_result))
         return matched_result
 
 
@@ -322,18 +322,19 @@ class ActionPop(MatchedAction):
         c_pos: int,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
+        rule_name = self._rule.resolved_rule_name
         try:
-            removed = parser.state.pop_rule_reference(self._rule.rule_name, matched_str)
+            removed = parser.state.pop_rule_reference(rule_name, matched_str)
         except (IndexError, KeyError):
             if parser.debug:
                 parser.dprint(
-                    f"-- The stack for `{self._rule.rule_name}` rule is empty at {c_pos} => "
+                    f"-- The stack for `{rule_name}` rule is empty at {c_pos} => "
                     f"'{parser.context(len(str(matched_result)))}'")
             parser._nm_raise(self, c_pos, parser)
 
         if not removed:
             if parser.debug:
-                match_against = parser.state.last_pushed_rule_reference(self._rule.rule_name)
+                match_against = parser.state.last_pushed_rule_reference(rule_name)
                 parser.dprint(
                     f"-- No match '{match_against}' at {c_pos} => "
                     f"'{parser.context(len(match_against))}'")
@@ -356,7 +357,7 @@ class ActionListAppend(MatchedAction):
             matched_str = ''
         else:
             matched_str = str(matched_result)
-        parser.state.append_rule_reference(self._rule.rule_name, matched_str)
+        parser.state.append_rule_reference(self._rule.resolved_rule_name, matched_str)
         return matched_result
 
 
@@ -378,12 +379,13 @@ class ActionListLast(MatchedAction):
         else:
             matched_str = str(matched_result)
 
+        rule_name = self._rule.resolved_rule_name
         try:
-            last = parser.state.last_rule_reference(self._rule.rule_name, self._state_scope)
+            last = parser.state.last_rule_reference(rule_name, self._state_scope)
         except (IndexError, KeyError):
             if parser.debug:
                 parser.dprint(
-                    f"-- The stack for `{self._rule.rule_name}` rule is empty at {c_pos} => "
+                    f"-- The stack for `{rule_name}` rule is empty at {c_pos} => "
                     f"'{parser.context(len(str(matched_result)))}'")
             parser._nm_raise(self, c_pos, parser)
 
@@ -408,7 +410,7 @@ class ActionTryRemoveLast(MatchedAction):
         matched_result: ParseTreeNode | None,
         c_pos: int,
     ) -> ParseTreeNode | None:
-        parser.state.try_remove_last_rule_reference(self._rule.rule_name)
+        parser.state.try_remove_last_rule_reference(self._rule.resolved_rule_name)
         return matched_result
 
 
@@ -435,12 +437,13 @@ class ActionLonger(MatchedAction):
         c_pos: int,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
+        rule_name =self._rule.resolved_rule_name
         try:
-            last = parser.state.last_rule_reference(self._rule.rule_name, self._state_scope)
+            last = parser.state.last_rule_reference(rule_name, self._state_scope)
         except (IndexError, KeyError):
             if parser.debug:
                 parser.dprint(
-                    f"-- The stack for `{self._rule.rule_name}` rule is empty or parent stack doesn't exist at {c_pos} => "
+                    f"-- The stack for `{rule_name}` rule is empty or parent stack doesn't exist at {c_pos} => "
                     f"'{parser.context(len(str(matched_result)))}'")
             parser._nm_raise(self, c_pos, parser)
 
@@ -474,18 +477,19 @@ class ActionPopFront(MatchedAction):
         c_pos: int,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
+        rule_name =self._rule.resolved_rule_name
         try:
-            removed = parser.state.pop_front_rule_reference(self._rule.rule_name, matched_str)
+            removed = parser.state.pop_front_rule_reference(rule_name, matched_str)
         except (IndexError, KeyError):
             if parser.debug:
                 parser.dprint(
-                    f"-- The stack for `{self._rule.rule_name}` rule is empty at {c_pos} => "
+                    f"-- The stack for `{rule_name}` rule is empty at {c_pos} => "
                     f"'{parser.context(len(str(matched_result)))}'")
             parser._nm_raise(self, c_pos, parser)
 
         if not removed:
             if parser.debug:
-                match_against = parser.state.first_pushed_rule_reference(self._rule.rule_name)
+                match_against = parser.state.first_pushed_rule_reference(rule_name)
                 parser.dprint(
                     f"-- No match '{match_against}' at {c_pos} => "
                     f"'{parser.context(len(match_against))}'")
@@ -506,7 +510,7 @@ class ActionAdd(MatchedAction):
         c_pos: int,
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
-        parser.state.remember_rule_reference(self._rule.rule_name, matched_str)
+        parser.state.remember_rule_reference(self._rule.resolved_rule_name, matched_str)
         return matched_result
 
 
@@ -523,7 +527,7 @@ class ActionParentAdd(MatchedAction):
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
-            self._rule.rule_name,
+            self._rule.resolved_rule_name,
             matched_str,
             state_layer_scope = LayerScope.PARENT  # noqa: E251
         )
@@ -543,7 +547,7 @@ class ActionGlobalAdd(MatchedAction):
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
         parser.state.remember_rule_reference(
-            self._rule.rule_name,
+            self._rule.resolved_rule_name,
             matched_str,
             state_layer_scope = LayerScope.GLOBAL  # noqa: E251
         )
@@ -563,7 +567,7 @@ class ActionAny(MatchedAction):
     ) -> ParseTreeNode | None:
         matched_str = str(matched_result)
 
-        is_known = parser.state.rule_reference_is_known(self._rule.rule_name, matched_str)
+        is_known = parser.state.rule_reference_is_known(self._rule.resolved_rule_name, matched_str)
         if not is_known:
             if parser.debug:
                 parser.dprint(
@@ -700,6 +704,12 @@ class MatchActions(ParsingExpression):
         for action in node.actions:
             action._rule = node.nodes[0]
         return node
+
+    @typing.override
+    @property
+    def resolved_rule_name(self):
+        return self.rule_name or self.nodes[0].rule_name
+
 
 
 class PEGVisitor(PTNodeVisitor):

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -162,11 +162,12 @@ def action_call():
 
 
 def action_call_argument():
-    return [_(r'\w+'), action_call_quoted_argument]
+    return [_(r'\w+'), quoted_string]
 
 
-def action_call_quoted_argument():
-    return str_match()
+def quoted_string():
+    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
+             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
 
 
 # PEG Lexical rules
@@ -184,8 +185,7 @@ def rule_crossref():
 
 
 def str_match():
-    return _(r'''(?s)('[^'\\]*(?:\\.[^'\\]*)*')|'''
-             r'''("[^"\\]*(?:\\.[^"\\]*)*")''')
+    return quoted_string()
 
 
 def comment():
@@ -673,7 +673,7 @@ class PEGVisitor(PTNodeVisitor):
     def visit_action_call(self, node, children):
         return children
 
-    def visit_action_call_quoted_argument(self, node, children):
+    def visit_quoted_string(self, node, children):
         matched_str = str(node)
         return self.decode_escaped_str(matched_str[1:-1])
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -70,7 +70,7 @@ def repeated_expression():      return expression, Optional([OPTIONAL,
                                                              ZERO_OR_MORE,
                                                              ONE_OR_MORE,
                                                              UNORDERED_GROUP])
-def expression():       return [operation, regex, rule_crossref,
+def expression():       return [regex, operation, rule_crossref,
                                 (OPEN, ordered_choice, CLOSE),
                                 str_match]
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -191,6 +191,9 @@ PEG_ESCAPE_SEQUENCES_RE = re.compile(r"""
 
 
 class MatchedAction:
+    """
+    An abstract class for all action classes used in MatchActions parsing rules.
+    """
     _rule: ParsingStatement
     _args: list[typing.Any] | None
 
@@ -210,6 +213,22 @@ class MatchedAction:
         c_pos: int,
         args = None,
     ):
+        """
+        This method must be implemented to run an action over the match result.
+
+        Parameters:
+        parser
+            A parser used to parse the source code.
+        matched_result
+            The match result that need to be processed by the action.
+        c_pos
+            The parser position before the corresponding (the MatchActions child rule) rule was matched.
+        args
+            Additional arguments that were passed to the action.
+
+        Returns:
+            A match result (usually the same as matched_result).
+        """
         pass
 
     def __str__(self):
@@ -217,6 +236,9 @@ class MatchedAction:
 
 
 class ActionPush(MatchedAction):
+    """
+    An action that is used to push a matched token onto the stack according to the rule name.
+    """
     @typing.override
     def run(
         self,
@@ -231,6 +253,9 @@ class ActionPush(MatchedAction):
 
 
 class ActionPop(MatchedAction):
+    """
+    An action that is used to remove a matched token from the top of the matches list according to the rule name.
+    """
     @typing.override
     def run(
         self,
@@ -261,6 +286,9 @@ class ActionPop(MatchedAction):
 
 
 class ActionPopFront(MatchedAction):
+    """
+    An action that is used to remove a matched token from the bottom of the matches list according to the rule name.
+    """
     @typing.override
     def run(
         self,
@@ -292,6 +320,9 @@ class ActionPopFront(MatchedAction):
 
 
 class ActionAdd(MatchedAction):
+    """
+    An action that is used to add a matched token to the set of matched tokens.
+    """
     @typing.override
     def run(
         self,
@@ -307,6 +338,9 @@ class ActionAdd(MatchedAction):
 
 
 class ActionParentAdd(MatchedAction):
+    """
+    An action that is used to add a matched token to the set of matched tokens of the parent state layer.
+    """
     @typing.override
     def run(
         self,
@@ -326,6 +360,9 @@ class ActionParentAdd(MatchedAction):
 
 
 class ActionGlobalAdd(MatchedAction):
+    """
+    An action that is used to add a matched token to the set of matched tokens of the global state layer.
+    """
     @typing.override
     def run(
         self,
@@ -345,6 +382,9 @@ class ActionGlobalAdd(MatchedAction):
 
 
 class ActionAny(MatchedAction):
+    """
+    An action that is used to check if the matched token was previously added to the set of the matched tokens.
+    """
     @typing.override
     def run(
         self,
@@ -368,6 +408,12 @@ class ActionAny(MatchedAction):
 
 
 class MatchActions(ParsingExpression):
+    """
+    Apply some actions to a matched rule.
+
+    This rule parses his child rule and then runs stored actions over the result. Each action except the first one
+    receives the previous action result and returns its own result (usually the same).
+    """
     actions: list[MatchedAction]
 
     def __init__(self, rule: ParsingStatement, actions: list[MatchedAction]):
@@ -654,6 +700,9 @@ class PEGVisitor(PTNodeVisitor):
 
 
 class ParserPEGStateLayer(ParserStateLayer):
+    """
+    A class that holds additional data used in PEG expressions.
+    """
     rule_reference_stack: dict[str, str]
     rule_reference_set: dict[str, str]
 
@@ -670,12 +719,18 @@ class ParserPEGStateLayer(ParserStateLayer):
 
 
 class StateLayerScope(enum.Enum):
+    """
+    An enumeration used to identify the stack layer that should be used in an expression.
+    """
     GLOBAL = 0
     PARENT = -2
     CURRENT = -1
 
 
 class ParserPEGState(ParserState):
+    """
+    A class that manages additional data used in PEG expressions.
+    """
     _state_layer_class: ParserStateLayer = ParserPEGStateLayer
 
     def __init__(self):

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -61,7 +61,7 @@ STATE_END = ']'
 def peggrammar():       return OneOrMore(rule), EOF
 def rule():             return rule_name, LEFT_ARROW, ordered_choice, ";"
 def ordered_choice():   return sequence, ZeroOrMore(ORDERED_CHOICE, sequence)
-def sequence():         return OneOrMore([operation, full_expression])
+def sequence():         return OneOrMore(full_expression)
 def operation():        return rule_crossref, calls
 def full_expression():  return Optional([AND, NOT]), expression_with_state
 def expression_with_state():    return Optional(state), repeated_expression
@@ -69,7 +69,7 @@ def repeated_expression():      return expression, Optional([OPTIONAL,
                                                              ZERO_OR_MORE,
                                                              ONE_OR_MORE,
                                                              UNORDERED_GROUP])
-def expression():       return [regex, rule_crossref,
+def expression():       return [operation, regex, rule_crossref,
                                 (OPEN, ordered_choice, CLOSE),
                                 str_match]
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -32,7 +32,6 @@ from arpeggio import (
     ZeroOrMore,
     visit_parse_tree,
     ParsingExpression,
-    MatchActions,
     MatchState,
 )
 from arpeggio import RegExMatch as _
@@ -101,6 +100,36 @@ PEG_ESCAPE_SEQUENCES_RE = re.compile(r"""
          N\{[- 0-9A-Z]+\}    # \\N{name} Unicode name or alias
        )
     """, re.VERBOSE | re.UNICODE)
+
+
+class MatchActions(ParsingExpression):
+    actions: list[list[str]]
+
+    def __init__(self, rule: ParsingExpression, actions: list[list[str]]):
+        super().__init__(rule_name='', nodes=[rule])
+        self.actions = actions
+
+    def _parse(self, parser: 'Parser'):
+        rule_node = self.nodes[0]
+        c_pos = parser.position
+        retval = rule_node.parse(parser)
+        for action in self.actions:
+            action_name = action[0]
+            action_method = getattr(parser.actions, action_name)
+            retval = action_method(rule_node, retval, c_pos, args=action[1:])
+        return retval
+
+    def __str__(self):
+        rule_node = self.nodes[0]
+        return str(rule_node)
+
+    @property
+    def desc(self):
+        return "{}{{{}}}{}".format(
+            self.name,
+            ', '.join(map(lambda x: ' '.join(x), self.actions)),
+            "-" if self.suppress else "",
+        )
 
 
 class PEGVisitor(PTNodeVisitor):

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -716,6 +716,46 @@ class ParserPEGStateLayer(ParserStateLayer):
         copied.rule_reference_set = copy.deepcopy(self.rule_reference_set, memo)
         return copied
 
+    def __bool__(self):
+        if super().__bool__():
+            return True
+
+        rule_reference_stack_is_empty = True
+        for key, value in self.rule_reference_stack.items():
+            if value:
+                rule_reference_stack_is_empty = False
+
+        rule_reference_set_is_empty = True
+        for key, value in self.rule_reference_set.items():
+            if value:
+                rule_reference_set_is_empty = False
+
+        if rule_reference_stack_is_empty and rule_reference_set_is_empty:
+            return False
+
+        return True
+
+
+    @typing.override
+    def queues_are_empty(self) -> bool:
+        if not super().queues_are_empty():
+            return False
+
+        rule_reference_stack_is_empty = True
+        for key, value in self.rule_reference_stack.items():
+            if value:
+                rule_reference_stack_is_empty = False
+
+        return rule_reference_stack_is_empty
+
+    def __str__(self):
+        return f"""{super().__str__()}
+Rule references queue:
+{str(self.rule_reference_stack)}
+Known rule references:
+{str(self.rule_reference_set)}
+"""
+
 
 class StateLayerScope(enum.Enum):
     """

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -88,10 +88,6 @@ def sequence():
     return OneOrMore(full_expression)
 
 
-def operation():
-    return rule_crossref, calls
-
-
 def full_expression():
     return Optional([AND, NOT]), repeated_expression
 
@@ -108,10 +104,10 @@ def repeated_expression():
 def expression():
     return [
         regex,
+        state,
         push_state,
         pop_state,
         wrapped_with_state_layer,
-        state,
         operation,
         rule_crossref,
         (OPEN, ordered_choice, CLOSE),
@@ -131,12 +127,32 @@ def pop_state():
     return POP_STATE, state_name
 
 
+def state_name():
+    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
+
+
 def wrapped_with_state_layer():
     return (
         STATE_LAYER_START,
         ordered_choice,
         STATE_LAYER_END
     )
+
+
+def operation():
+    return rule_crossref, calls
+
+
+def calls():
+    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+
+
+def call():
+    return OneOrMore(call_argument)
+
+
+def call_argument():
+    return _(r'[^\} \t,]+')
 
 
 # PEG Lexical rules
@@ -160,22 +176,6 @@ def str_match():
 
 def comment():
     return _("//.*\n", multiline=False)
-
-
-def calls():
-    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
-
-
-def call():
-    return OneOrMore(call_argument)
-
-
-def call_argument():
-    return _(r'[^\} \t,]+')
-
-
-def state_name():
-    return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
 # Escape sequences supported in PEG literal string matches

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -8,11 +8,11 @@
 #######################################################################
 import abc
 import codecs
+import collections.abc
 import copy
 import enum
 import re
 import typing
-import collections.abc
 
 
 from arpeggio import (
@@ -692,7 +692,7 @@ class MatchActions(ParsingExpression):
         self,
         resolve_cb: typing.Callable[[ParserModelItem], ParserModelItem]
     ) -> 'MatchActions':
-        node = super().resolve(resolve_cb)
+        node = typing.cast(typing.Self, super().resolve(resolve_cb))
         for action in node.actions:
             action._rule = node.nodes[0]
         return node

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -289,6 +289,13 @@ class ParserPEGActions:
 
     def pop(self, rule: Match, matched_result, c_pos, args=None):
         stack = self._parser.state.rule_reference_stack
+        if not stack.get(rule.rule_name):
+            if self._parser.debug:
+                self._parser.dprint(
+                    f"-- The stack for `{rule.rule_name}` rule is empty at {c_pos} => "
+                    f"'{self._parser.context(len(str(matched_result)))}'")
+            self._parser._nm_raise(rule, c_pos, self._parser)
+
         match_against = stack[rule.rule_name][-1]
 
         matched_str = str(matched_result)

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -586,11 +586,15 @@ class ActionFirstLonger(MatchedAction):
         last_value = parser.state.repetition_last_rule_reference(rule_name)
         if last_value is None:
             parent_value = parser.state.repetition_last_rule_reference(rule_name, LayerScope.PARENT)
-            if parent_value is not None and len(matched_str) <= len(parent_value):
+
+            if (
+                (parent_value is not None and len(matched_str) <= len(parent_value))
+                or (parent_value is None and len(matched_str) > 0)
+            ):
                 if parser.debug:
                     parser.dprint(
                         f"-- Matched repetition '{matched_str}' token is not longer than "
-                        f"parent token '{parent_value}' at {c_pos} => '{parser.context(len(matched_str))}'")
+                        f"parent token '{str(parent_value)}' at {c_pos} => '{parser.context(len(matched_str))}'")
                 parser._nm_raise(self._rule, c_pos, parser)
 
             parser.state.repetition_set_rule_reference(rule_name, matched_str)

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -416,7 +416,7 @@ class ActionLonger(MatchedAction):
         if len(matched_str) <= len(last):
             if parser.debug:
                 parser.dprint(
-                    f"-- Match '{matched_str}' is not longer than parent's 'last' at {c_pos} => "
+                    f"-- Match '{matched_str}' is not longer than parent's '{last}' at {c_pos} => "
                     f"'{parser.context(len(matched_str))}'")
             parser._nm_raise(self._rule, c_pos, parser)
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -42,7 +42,7 @@ from arpeggio import (
     MatchState,
     PushState,
     PopState,
-    WrappedWithStateLayer,
+    StateWrapper,
     ParsingState, ParserModelItem,
 )
 from arpeggio import RegExMatch as _
@@ -656,7 +656,7 @@ class PEGVisitor(PTNodeVisitor):
         return PopState(parsing_state)
 
     def visit_wrapped_with_state_layer(self, node, children):
-        return WrappedWithStateLayer(children[0])
+        return StateWrapper(children[0])
 
     def visit_repeated_expression(self, node, children):
         if len(children) == 1:

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -204,7 +204,7 @@ PEG_ESCAPE_SEQUENCES_RE = re.compile(r"""
     """, re.VERBOSE | re.UNICODE)
 
 
-class StateLayerScope(enum.Enum):
+class LayerScope(enum.Enum):
     """
     An enumeration used to identify the stack layer that should be used in an expression.
     """
@@ -330,7 +330,7 @@ class ActionListLast(MatchedAction):
     """
     An action that is used to match the last matched token from the top of the matches list according to the rule name.
     """
-    _state_scope: StateLayerScope = StateLayerScope.CURRENT
+    _state_scope: LayerScope = LayerScope.CURRENT
 
     @typing.override
     def run(
@@ -385,7 +385,7 @@ class ActionParentListLast(ActionListLast):
     An action that is used to match the last matched token from the top of the matches list of the parent's stack layer
     according to the rule name.
     """
-    _state_scope: StateLayerScope = StateLayerScope.PARENT
+    _state_scope: LayerScope = LayerScope.PARENT
 
 
 class ActionLonger(MatchedAction):
@@ -393,7 +393,7 @@ class ActionLonger(MatchedAction):
     An action that is used to match a longer token than the last matched token from the top of the matches list
     according to the rule name.
     """
-    _state_scope: StateLayerScope = StateLayerScope.CURRENT
+    _state_scope: LayerScope = LayerScope.CURRENT
 
     @typing.override
     def run(
@@ -428,7 +428,7 @@ class ActionParentListLonger(ActionLonger):
     An action that is used to match a longer token than the last matched token from the top of the matches list of
     the parent's stack layer according to the rule name.
     """
-    _state_scope: StateLayerScope = StateLayerScope.PARENT
+    _state_scope: LayerScope = LayerScope.PARENT
 
 
 class ActionPopFront(MatchedAction):
@@ -497,7 +497,7 @@ class ActionParentAdd(MatchedAction):
         parser.state.remember_rule_reference(
             self._rule.rule_name,
             matched_str,
-            state_layer_scope = StateLayerScope.PARENT  # noqa: E251
+            state_layer_scope = LayerScope.PARENT  # noqa: E251
         )
         return matched_result
 
@@ -518,7 +518,7 @@ class ActionGlobalAdd(MatchedAction):
         parser.state.remember_rule_reference(
             self._rule.rule_name,
             matched_str,
-            state_layer_scope = StateLayerScope.GLOBAL  # noqa: E251
+            state_layer_scope = LayerScope.GLOBAL  # noqa: E251
         )
         return matched_result
 
@@ -1009,7 +1009,7 @@ class ParserPEGState(ParserState):
     def last_pushed_rule_reference(
         self,
         rule_name: str,
-        state_layer_scope: StateLayerScope = StateLayerScope.CURRENT,
+        state_layer_scope: LayerScope = LayerScope.CURRENT,
     ) -> str | None:
         layer_num = state_layer_scope.value
         stack = self.state_layers[layer_num].rule_reference_stack[rule_name]
@@ -1041,7 +1041,7 @@ class ParserPEGState(ParserState):
     def last_rule_reference(
         self,
         rule_name: str,
-        state_layer_scope: StateLayerScope = StateLayerScope.CURRENT,
+        state_layer_scope: LayerScope = LayerScope.CURRENT,
     ) -> str | None:
         layer_num = state_layer_scope.value
         stack = self.state_layers[layer_num].rule_reference_list[rule_name]
@@ -1053,7 +1053,7 @@ class ParserPEGState(ParserState):
         self,
         rule_name: str,
         reference_name: str,
-        state_layer_scope: StateLayerScope = StateLayerScope.CURRENT
+        state_layer_scope: LayerScope = LayerScope.CURRENT
     ):
         layer_num = state_layer_scope.value
         reference_set = self.state_layers[layer_num].rule_reference_set.setdefault(rule_name, set())

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -104,9 +104,9 @@ def repeated_expression():
 def expression():
     return [
         regex,
-        state,
-        push_state,
-        pop_state,
+        parsing_state,
+        push_parsing_state,
+        pop_parsing_state,
         wrapped_with_state_layer,
         operation,
         rule_crossref,
@@ -115,19 +115,19 @@ def expression():
     ]
 
 
-def state():
-    return STATE, state_name
+def parsing_state():
+    return STATE, parsing_state_name
 
 
-def push_state():
-    return PUSH_STATE, state_name
+def push_parsing_state():
+    return PUSH_STATE, parsing_state_name
 
 
-def pop_state():
-    return POP_STATE, state_name
+def pop_parsing_state():
+    return POP_STATE, parsing_state_name
 
 
-def state_name():
+def parsing_state_name():
     return _(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
 
@@ -140,18 +140,18 @@ def wrapped_with_state_layer():
 
 
 def operation():
-    return rule_crossref, calls
+    return rule_crossref, action_calls
 
 
-def calls():
-    return CALL_START, call, ZeroOrMore([CALL_DELIMITER, call]), CALL_END
+def action_calls():
+    return CALL_START, action_call, ZeroOrMore([CALL_DELIMITER, action_call]), CALL_END
 
 
-def call():
-    return OneOrMore(call_argument)
+def action_call():
+    return OneOrMore(action_call_argument)
 
 
-def call_argument():
+def action_call_argument():
     return _(r'[^\} \t,]+')
 
 
@@ -591,21 +591,21 @@ class PEGVisitor(PTNodeVisitor):
 
         return retval
 
-    def visit_calls(self, node, children):
-        call_arguments = [arg for arg in node if arg.rule_name == 'call']
+    def visit_action_calls(self, node, children):
+        call_arguments = [arg for arg in node if arg.rule_name == 'action_call']
         return call_arguments
 
-    def visit_state(self, node, children):
+    def visit_parsing_state(self, node, children):
         state_name = str(node[1])
         parsing_state = self.get_state_by_name(state_name)
         return MatchState(parsing_state)
 
-    def visit_push_state(self, node, children):
+    def visit_push_parsing_state(self, node, children):
         state_name = str(node[1])
         parsing_state = self.get_state_by_name(state_name)
         return PushState(parsing_state)
 
-    def visit_pop_state(self, node, children):
+    def visit_pop_parsing_state(self, node, children):
         state_name = str(node[1])
         parsing_state = self.get_state_by_name(state_name)
         return PopState(parsing_state)

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -66,14 +66,14 @@ AND = "&"
 NOT = "!"
 OPEN = "("
 CLOSE = ")"
-CALL_START = "{"
-CALL_END = "}"
-CALL_DELIMITER = ','
-STATE = '@'
-PUSH_STATE = '+@'
-POP_STATE = '-@'
-STATE_LAYER_START = '@('
-STATE_LAYER_END = ')'
+CALL_START = StrMatch("{", suppress=True)
+CALL_END = StrMatch("}", suppress=True)
+CALL_DELIMITER = StrMatch(',', suppress=True)
+STATE = StrMatch('@', suppress=True)
+PUSH_STATE = StrMatch('+@', suppress=True)
+POP_STATE = StrMatch('-@', suppress=True)
+STATE_LAYER_START = StrMatch('@(', suppress=True)
+STATE_LAYER_END = StrMatch(')', suppress=True)
 
 
 # PEG syntax rules
@@ -154,7 +154,7 @@ def wrapped_with_state_layer():
 
 
 def action_calls():
-    return CALL_START, action_call, ZeroOrMore([CALL_DELIMITER, action_call]), CALL_END
+    return CALL_START, action_call, ZeroOrMore((CALL_DELIMITER, action_call)), CALL_END
 
 
 def action_call():
@@ -162,7 +162,7 @@ def action_call():
 
 
 def action_call_argument():
-    return _(r'[^\} \t,]+')
+    return _(r'\w+')
 
 
 # PEG Lexical rules
@@ -664,21 +664,23 @@ class PEGVisitor(PTNodeVisitor):
         return retval
 
     def visit_action_calls(self, node, children):
-        call_arguments = [arg for arg in node if arg.rule_name == 'action_call']
-        return call_arguments
+        return children
+
+    def visit_action_call(self, node, children):
+        return children
 
     def visit_parsing_state(self, node, children):
-        state_name = str(node[1])
+        state_name = str(node)
         parsing_state = self.get_state_by_name(state_name)
         return MatchState(parsing_state)
 
     def visit_push_parsing_state(self, node, children):
-        state_name = str(node[1])
+        state_name = str(node)
         parsing_state = self.get_state_by_name(state_name)
         return PushState(parsing_state)
 
     def visit_pop_parsing_state(self, node, children):
-        state_name = str(node[1])
+        state_name = str(node)
         parsing_state = self.get_state_by_name(state_name)
         return PopState(parsing_state)
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -351,7 +351,7 @@ class ActionParentAdd(MatchedAction):
         parser.state.remember_rule_reference(
             self._rule.rule_name,
             matched_str,
-            state_layer_scope = StateLayerScope.PARENT
+            state_layer_scope = StateLayerScope.PARENT  # noqa: E251
         )
         return matched_result
 
@@ -372,7 +372,7 @@ class ActionGlobalAdd(MatchedAction):
         parser.state.remember_rule_reference(
             self._rule.rule_name,
             matched_str,
-            state_layer_scope = StateLayerScope.GLOBAL
+            state_layer_scope = StateLayerScope.GLOBAL  # noqa: E251
         )
         return matched_result
 

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -593,7 +593,7 @@ class ParserPEGState(ParserState):
 
 
 class ParserPEG(Parser):
-    state_class: type[ParserState] = ParserPEGState
+    _state_class: type[ParserState] = ParserPEGState
 
     def __init__(self, language_def, root_rule_name, comment_rule_name=None,
                  *args, **kwargs):

--- a/arpeggio/peg.py
+++ b/arpeggio/peg.py
@@ -535,6 +535,7 @@ class ParserPEGActions:
 
 class ParserPEG(Parser):
     state_class: type[ParserState] = ParserPEGState
+    actions_class: type[ParserPEGActions] = ParserPEGActions
 
     def __init__(self, language_def, root_rule_name, comment_rule_name=None,
                  *args, **kwargs):
@@ -549,7 +550,7 @@ class ParserPEG(Parser):
         """
         super().__init__(*args, **kwargs)
 
-        self.actions = ParserPEGActions(self)
+        self.actions = self.actions_class(self)
 
         self.root_rule_name = root_rule_name
         self.comment_rule_name = comment_rule_name

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -107,8 +107,14 @@ end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
-    assert len(parser.state.rule_reference_set['function_name']) == 2
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
+
+    function_names = parser.state.known_rule_references('function_name')
+    assert isinstance(function_names, set)
+    assert len(function_names) == 2
 
     if parser.debug:
         output = capsys.readouterr()
@@ -133,7 +139,10 @@ function_name2(1, 2, 3)
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
 
     if parser.debug:
         output = capsys.readouterr()
@@ -165,7 +174,10 @@ end of function_name3
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
 
     if parser.debug:
         output = capsys.readouterr()
@@ -200,7 +212,10 @@ end of function_name3
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
     assert len(parser.state.states_stack) == 0
 
     if parser.debug:
@@ -236,7 +251,10 @@ end of function_name3
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
     assert len(parser.state.states_stack) == 0
 
     if parser.debug:
@@ -258,8 +276,14 @@ end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
-    assert len(parser.state.rule_reference_stack['function_name']) == 0
-    assert len(parser.state.rule_reference_set['function_name']) == 2
+
+    with pytest.raises(Exception) as e:
+        parser.state.pop_rule_reference('function_name')
+    assert e is not None
+
+    function_names = parser.state.known_rule_references('function_name')
+    assert isinstance(function_names, set)
+    assert len(function_names) == 2
 
     if parser.debug:
         output = capsys.readouterr()

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -33,7 +33,7 @@ program_element <-
 function <-
     FUNCTION_START function_name{push, add}
     program_element*
-    FUNCTION_END function_name{pop};
+    FUNCTION_END &function_name{pop} function_name{pop};
 
 alternative_function <-
     FUNCTION_START function_name{push, add}

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -33,9 +33,11 @@ program_element <-
 function <-
     FUNCTION_START function_name{push, add}
     program_element*
+    // Test And expression not changing the state of the parser
     FUNCTION_END &function_name{pop} function_name{pop};
 
 alternative_function <-
+    // Test branching with push action
     FUNCTION_START function_name{push, add}
     program_element*
     '/' function_name{pop};

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -100,6 +100,7 @@ END <- 'end';
 GLOBAL <- r'global(?=\s)';
 '''
 
+
 def get_clean_grammar():
     return get_grammar().replace('<-', '=').replace(';', '')
 
@@ -123,7 +124,7 @@ def function_name2
 end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -136,6 +137,7 @@ end of function_name2
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -155,7 +157,7 @@ function_name1(1, 2, 3)
 function_name2(1, 2, 3)
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -164,6 +166,7 @@ function_name2(1, 2, 3)
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -190,7 +193,7 @@ end of function_name3
 
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -199,6 +202,7 @@ end of function_name3
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -228,7 +232,7 @@ end of function_name3
 
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -239,44 +243,6 @@ end of function_name3
         output = capsys.readouterr()
         assert 'states stack' in output.out
 
-@pytest.mark.parametrize('klass, grammar_cb, debug', [
-    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, Debugging.ENABLED),
-])
-def test_backreference_with_state(klass, grammar_cb, debug, capsys):
-    input = """
-def function_name1
-end of function_name1
-
-def function_name2
-end of function_name2
-
-def function_name3
-    anonymous defer
-    anonymous defer
-
-    deferred
-        function_name1(1, 2, 3)
-    end
-
-    deferred
-        function_name2(1, 2, 3)
-    end
-end of function_name3
-
-"""
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
-
-    with pytest.raises(Exception) as e:
-        parser.state.pop_rule_reference('function_name')
-    assert e is not None
-    assert len(parser.state.states_stack) == 0
-
-    if parser.debug:
-        output = capsys.readouterr()
-        assert 'states stack' in output.out
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -292,7 +258,7 @@ def function_name2
 end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -306,6 +272,7 @@ end of function_name2
         output = capsys.readouterr()
         assert 'states stack' in output.out
 
+
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
@@ -318,7 +285,7 @@ end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     with pytest.raises(arpeggio.NoMatch) as e:
-        result = parser.parse(input)
+        parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -327,6 +294,7 @@ end of function_name2
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -341,7 +309,7 @@ end of function_name1
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     with pytest.raises(arpeggio.NoMatch) as e:
-        result = parser.parse(input)
+        parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -350,6 +318,7 @@ end of function_name1
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -366,7 +335,7 @@ end of function_name1
 global_function_name(1, 2, 3)
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    result = parser.parse(input)
+    parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -375,6 +344,7 @@ global_function_name(1, 2, 3)
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
@@ -392,7 +362,7 @@ local_function_name(1, 2, 3)
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     with pytest.raises(arpeggio.NoMatch) as e:
-        result = parser.parse(input)
+        parser.parse(input)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -1,0 +1,66 @@
+#######################################################################
+# Name: test_peg_parser
+# Purpose: Test for parser constructed using PEG textual grammars.
+# Authors: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@yandex.ru>
+# Copyright: (c) 2025
+#           Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>,
+#           Andrey N. Dotsenko <pgandrey@yandex.ru>
+# License: MIT License
+#
+# This file is originally based on test_peg_parser.py
+#######################################################################
+
+import pytest
+from arpeggio.peg import ParserPEG
+from arpeggio.cleanpeg import ParserPEG as ParserPEGClean
+
+grammar = r'''
+parser_entry <- program_element* EOF;
+
+program_element <-
+    function
+    / function_call;
+
+function <-
+    FUNCTION_START function_name{push}
+    program_element*
+    FUNCTION_END function_name{pop};
+
+function_call <-
+    function_name
+    ARGUMENTS_START
+    VALID_NAME?
+    (
+        ARGUMENTS_DELIMITER
+        VALID_NAME
+    )*
+    ARGUMENTS_DELIMITER?
+    ARGUMENTS_END;
+
+FUNCTION_START <- 'def';
+function_name <- VALID_NAME;
+FUNCTION_END <- 'end of';
+ARGUMENTS_START <- '(';
+ARGUMENTS_END <- ')';
+VALID_NAME <- r'[a-zA-Z0-9_]+';
+ARGUMENTS_DELIMITER <- ',';
+'''
+
+clean_grammar = grammar.replace('<-', '=').replace(';', '')
+
+@pytest.mark.parametrize('parser', [
+    ParserPEGClean(clean_grammar, 'parser_entry'),
+    ParserPEG(grammar, 'parser_entry'),
+])
+def test_backreference(parser):
+    input = """
+def function_name1
+end of function_name1
+
+def function_name2
+    function_name1(arg1)
+end of function_name2
+
+function_name(1, 2, 3)
+    """
+    result = parser.parse(input)

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -99,6 +99,9 @@ end of function_name2
     """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
+    assert len(parser.state.rule_reference_stack['function_name']) == 0
+    assert len(parser.state.rule_reference_set['function_name']) == 2
+
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
@@ -122,6 +125,8 @@ function_name2(1, 2, 3)
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
+    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
@@ -152,6 +157,8 @@ end of function_name3
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
+    assert len(parser.state.rule_reference_stack['function_name']) == 0
+
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
@@ -185,7 +192,47 @@ end of function_name3
 """
     parser = klass(grammar_cb(), 'parser_entry', debug=debug)
     result = parser.parse(input)
+    assert len(parser.state.rule_reference_stack['function_name']) == 0
     assert len(parser.state.states_stack) == 0
+
     if parser.debug:
         output = capsys.readouterr()
         assert 'states stack' in output.out
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
+])
+def test_backreference_with_state(klass, grammar_cb, debug, capsys):
+    input = """
+def function_name1
+end of function_name1
+
+def function_name2
+end of function_name2
+
+def function_name3
+    anonymous defer
+    anonymous defer
+
+    deferred
+        function_name1(1, 2, 3)
+    end
+
+    deferred
+        function_name2(1, 2, 3)
+    end
+end of function_name3
+
+"""
+    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
+    result = parser.parse(input)
+    assert len(parser.state.rule_reference_stack['function_name']) == 0
+    assert len(parser.state.states_stack) == 0
+
+    if parser.debug:
+        output = capsys.readouterr()
+        assert 'states stack' in output.out
+
+

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -51,12 +51,13 @@ global_function <-
     );
 
 alternative_function <-
+    // Test branching with push action
+    FUNCTION_START function_name{push, add}
     @(
-        // Test branching with push action
-        FUNCTION_START function_name{push, parent add}
         program_element*
-        '/' function_name{pop}
-    );
+        // `*` operator is greedy so the closing `)` won't be matched until all the program_element statements are found
+    )
+    '/' function_name{pop};
 
 function_call <-
     function_name{any}

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -22,12 +22,12 @@ program_element <-
     / function_call;
 
 function <-
-    FUNCTION_START function_name{push}
+    FUNCTION_START function_name{push, add}
     program_element*
     FUNCTION_END function_name{pop};
 
 function_call <-
-    function_name
+    function_name{any}
     ARGUMENTS_START
     VALID_NAME?
     (
@@ -58,9 +58,25 @@ def function_name1
 end of function_name1
 
 def function_name2
+end of function_name2
+    """
+    result = parser.parse(input)
+
+@pytest.mark.parametrize('parser', [
+    ParserPEGClean(clean_grammar, 'parser_entry'),
+    ParserPEG(grammar, 'parser_entry'),
+])
+def test_backreference_any(parser):
+    input = """
+def function_name1
+end of function_name1
+
+def function_name2
     function_name1(arg1)
 end of function_name2
 
-function_name(1, 2, 3)
-    """
+function_name1(1, 2, 3)
+function_name2(1, 2, 3)
+"""
     result = parser.parse(input)
+

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -31,16 +31,20 @@ program_element <-
     / function_call;
 
 function <-
-    FUNCTION_START function_name{push, add}
-    program_element*
-    // Test And expression not changing the state of the parser
-    FUNCTION_END &function_name{pop} function_name{pop};
+    @(
+        FUNCTION_START function_name{push, parent add}
+            program_element*
+        // Test And expression not changing the state of the parser
+        FUNCTION_END &function_name{pop} function_name{pop}
+    );
 
 alternative_function <-
-    // Test branching with push action
-    FUNCTION_START function_name{push, add}
-    program_element*
-    '/' function_name{pop};
+    @(
+        // Test branching with push action
+        FUNCTION_START function_name{push, parent add}
+        program_element*
+        '/' function_name{pop}
+    );
 
 function_call <-
     function_name{any}
@@ -62,12 +66,12 @@ defer <-
 defer_name <- VALID_NAME;
 
 anonymous_defer <-
-    ANONYMOUS_DEFER{state push anonymous_defer};
+    ANONYMOUS_DEFER +@anonymous_defer;
 
 anonymous_deferred <-
-    [anonymous_defer]DEFERRED
+    @anonymous_defer DEFERRED
     program_element*
-    END{state pop anonymous_defer};
+    END -@anonymous_defer;
 
 FUNCTION_START <- 'def';
 function_name <- VALID_NAME;

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -117,15 +117,15 @@ class Debugging(enum.Flag):
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 end of function_name1
 
 def function_name2
 end of function_name2
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -146,7 +146,7 @@ end of function_name2
     (ParserPEG, get_grammar, True),
 ])
 def test_backreference_any(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 end of function_name1
 
@@ -157,8 +157,8 @@ end of function_name2
 function_name1(1, 2, 3)
 function_name2(1, 2, 3)
 """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -175,7 +175,7 @@ function_name2(1, 2, 3)
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_pop_front(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 end of function_name1
 
@@ -193,8 +193,8 @@ def function_name3
 end of function_name3
 
 """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -211,7 +211,7 @@ end of function_name3
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_with_state(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 end of function_name1
 
@@ -232,8 +232,8 @@ def function_name3
 end of function_name3
 
 """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -251,15 +251,15 @@ end of function_name3
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_with_lookahead(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 /function_name1
 
 def function_name2
 end of function_name2
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -280,13 +280,13 @@ end of function_name2
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_not_found(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
 end of function_name2
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    with pytest.raises(arpeggio.NoMatch) as e:
-        parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    with pytest.raises(arpeggio.NoMatch):
+        parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -303,14 +303,14 @@ end of function_name2
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_any_not_found(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
     not_found(1, 2, 3)
 end of function_name1
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    with pytest.raises(arpeggio.NoMatch) as e:
-        parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    with pytest.raises(arpeggio.NoMatch):
+        parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -327,7 +327,7 @@ end of function_name1
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_global_add(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
     global def global_function_name
     end of global_function_name
@@ -335,8 +335,8 @@ end of function_name1
 
 global_function_name(1, 2, 3)
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
@@ -353,7 +353,7 @@ global_function_name(1, 2, 3)
     (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrapping_with_state_layer(klass, grammar_cb, debug, capsys):
-    input = """
+    input_text = """
 def function_name1
     def local_function_name
     end of local_function_name
@@ -361,9 +361,9 @@ end of function_name1
 
 local_function_name(1, 2, 3)
     """
-    parser = klass(grammar_cb(), 'parser_entry', debug=debug)
-    with pytest.raises(arpeggio.NoMatch) as e:
-        parser.parse(input)
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    with pytest.raises(arpeggio.NoMatch):
+        parser.parse(input_text)
 
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')

--- a/arpeggio/tests/test_peg_actions.py
+++ b/arpeggio/tests/test_peg_actions.py
@@ -237,7 +237,7 @@ end of function_name3
     with pytest.raises(Exception) as e:
         parser.state.pop_rule_reference('function_name')
     assert e is not None
-    assert len(parser.state.states_stack) == 0
+    assert parser.state.parsing_state is None
 
     if parser.debug:
         output = capsys.readouterr()

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -73,11 +73,13 @@ function_with_suppressed_keywords <-
 function_call <-
     function_name{any}
     ARGUMENTS_START
-    VALID_NAME?
     (
-        ARGUMENTS_DELIMITER
         VALID_NAME
-    )*
+        (
+            ARGUMENTS_DELIMITER
+            VALID_NAME
+        )*
+    )?
     ARGUMENTS_DELIMITER?
     ARGUMENTS_END;
 

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -201,8 +201,9 @@ def test_backreference_non_pushed(klass, grammar_cb, debug, capsys):
 erroneous end of function_name1
     """
     parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
-    with pytest.raises(arpeggio.NoMatch):
+    with pytest.raises(arpeggio.NoMatch) as err_info:
         parser.parse(input_text)
+    assert 'function_name{..., pop, ...}' in str(err_info.value)
 
 
 @pytest.mark.parametrize('klass, grammar_cb, debug', [

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -75,12 +75,8 @@ function_call <-
     ARGUMENTS_START
     (
         VALID_NAME
-        (
-            ARGUMENTS_DELIMITER
-            VALID_NAME
-        )*
-    )?
-    ARGUMENTS_DELIMITER?
+        % ARGUMENTS_DELIMITER
+    )*
     ARGUMENTS_END;
 
 defer_call <-

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -208,7 +208,7 @@ erroneous end of function_name1
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_any(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -249,7 +249,7 @@ function_name2(1, 2, 3)
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_backreference_any_not_met(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -598,7 +598,7 @@ erroneous end of function_name1
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_suppress_action(klass, grammar_cb, debug, capsys):
     input_text = """

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -1,6 +1,6 @@
 #######################################################################
-# Name: test_peg_parser
-# Purpose: Test for parser constructed using PEG textual grammars.
+# Name: test_peg_actions_and_states
+# Purpose: Test for parser constructed using PEG textual grammars using the actions and states system.
 # Authors: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@yandex.ru>
 # Copyright: (c) 2025
 #           Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>,

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -101,7 +101,7 @@ ARGUMENTS_START <- '(';
 ARGUMENTS_END <- ')';
 VALID_NAME <- r'[a-zA-Z0-9_]+';
 ARGUMENTS_DELIMITER <- ',';
-DEFER <- 'defer';
+DEFER <- r'defer(?=\s)';
 DEFER_DELIMITER <- ':';
 ANONYMOUS_DEFER <- 'anonymous defer';
 DEFERRED <- 'deferred';
@@ -326,6 +326,27 @@ end of function_name1
 deferred
     function_name1(1, 2, 3)
 end
+"""
+    parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
+    with pytest.raises(arpeggio.NoMatch):
+        parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
+])
+def test_backreference_with_wrong_state_in_state_layer(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+    deferred
+        function_name1(1, 2, 3)
+    end
+end of function_name2
 """
     parser: ParserPEG = klass(grammar_cb(), 'parser_entry', debug=debug)
     with pytest.raises(arpeggio.NoMatch):

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -41,7 +41,8 @@ function <-
         FUNCTION_START function_name{push, parent add}
             program_element*
         // Test And expression not changing the state of the parser
-        FUNCTION_END &function_name{pop} function_name{pop}
+        // Also, test quoted argument
+        FUNCTION_END &function_name{'pop'} function_name{pop}
     );
 
 global_function <-
@@ -66,7 +67,7 @@ function_with_suppressed_keywords <-
     @(
         FUNCTION_START_SUPPRESSED function_name{push, parent add}
             program_element*
-        FUNCTION_END_SUPPRESSED function_name{pop, suppress}
+        FUNCTION_END_SUPPRESSED function_name{pop, 'suppress'}
     );
 
 function_call <-

--- a/arpeggio/tests/test_peg_actions_and_states.py
+++ b/arpeggio/tests/test_peg_actions_and_states.py
@@ -56,7 +56,8 @@ global_function <-
 
 alternative_function <-
     // Test branching with push action
-    FUNCTION_START function_name{push, add}
+    // Also test resolving rule name by using a nested action
+    FUNCTION_START (function_name{push}){add}
     @(
         program_element*
         // `*` operator is greedy so the closing `)` won't be matched until all the program_element statements are found

--- a/arpeggio/tests/test_peg_indentation.py
+++ b/arpeggio/tests/test_peg_indentation.py
@@ -1,0 +1,164 @@
+#######################################################################
+# Name: test_peg_indentation
+# Purpose: Test actions that can be used to parse indentation.
+# Authors: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@yandex.ru>
+# Copyright: (c) 2025
+#           Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>,
+#           Andrey N. Dotsenko <pgandrey@yandex.ru>
+# License: MIT License
+#
+# This file is originally based on test_peg_actions_and_states.py
+#######################################################################
+
+import pytest
+
+from arpeggio import NoMatch
+from arpeggio.peg import ParserPEG
+from arpeggio.cleanpeg import ParserPEG as ParserPEGClean
+import enum
+
+
+# Functions are used instead of variables to store grammar only to make parametrized test results readable
+def get_grammar():
+    return r'''
+parser_entry <-
+    (
+        INDENTATION{append, suppress} program_element
+        (INDENTATION{last, suppress} program_element)*
+    )?
+    EOF;
+
+program_element <-
+    function_with_underscores
+    / function_call;
+
+function_with_underscores <-
+    @(
+        FUNCTION_START function_name{push, parent add}
+        (
+            INDENTATION{parent longer, append, suppress} program_element
+            (INDENTATION{last, suppress} program_element)*
+        )?
+        INDENTATION{parent last, try remove, suppress} FUNCTION_END function_name{pop}
+    );
+
+
+function_call <-
+    function_name{any}
+    ARGUMENTS_START
+    VALID_NAME?
+    (
+        ARGUMENTS_DELIMITER
+        VALID_NAME
+    )*
+    ARGUMENTS_DELIMITER?
+    ARGUMENTS_END;
+
+FUNCTION_START <- 'def';
+function_name <- VALID_NAME;
+FUNCTION_END <- 'end of';
+ARGUMENTS_START <- '(';
+ARGUMENTS_END <- ')';
+VALID_NAME <- r'[a-zA-Z0-9_]+';
+ARGUMENTS_DELIMITER <- ',';
+INDENTATION <- r'_*';
+'''
+
+
+def get_clean_grammar():
+    return get_grammar().replace('<-', '=').replace(';', '')
+
+
+class Debugging(enum.Flag):
+    ENABLED = True
+    DISABLED = False
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_parent_last_last_longer(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+____def inner_function_name
+________function_name1(1, 2, 3)
+________function_name2(4, 5, 6)
+____end of inner_function_name
+end of function_name2
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_wrong_indentation(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+
+____def inner_function_name
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+____end of inner_function_name
+end of function_name2
+
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    with pytest.raises(NoMatch):
+        parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_wrong_indentation_at_end(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+
+____def inner_function_name
+______function_name1(1, 2, 3)
+______function_name2(4, 5, 6)
+___end of inner_function_name
+end of function_name2
+
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    with pytest.raises(NoMatch):
+        parser.parse(input_text)

--- a/arpeggio/tests/test_peg_indentation.py
+++ b/arpeggio/tests/test_peg_indentation.py
@@ -48,11 +48,8 @@ function_call <-
     ARGUMENTS_START
     (
         VALID_NAME
-        (
-            ARGUMENTS_DELIMITER
-            VALID_NAME
-        )*
-    )?
+        % ARGUMENTS_DELIMITER
+    )*
     ARGUMENTS_DELIMITER?
     ARGUMENTS_END;
 

--- a/arpeggio/tests/test_peg_indentation.py
+++ b/arpeggio/tests/test_peg_indentation.py
@@ -46,11 +46,13 @@ function_with_underscores <-
 function_call <-
     function_name{any}
     ARGUMENTS_START
-    VALID_NAME?
     (
-        ARGUMENTS_DELIMITER
         VALID_NAME
-    )*
+        (
+            ARGUMENTS_DELIMITER
+            VALID_NAME
+        )*
+    )?
     ARGUMENTS_DELIMITER?
     ARGUMENTS_END;
 

--- a/arpeggio/tests/test_peg_indentation.py
+++ b/arpeggio/tests/test_peg_indentation.py
@@ -23,8 +23,8 @@ def get_grammar():
     return r'''
 parser_entry <-
     (
-        INDENTATION{append, suppress} program_element
-        (INDENTATION{last, suppress} program_element)*
+        INDENTATION{list append, suppress} program_element
+        (INDENTATION{list last, suppress} program_element)*
     )?
     EOF;
 
@@ -36,10 +36,10 @@ function_with_underscores <-
     @(
         FUNCTION_START function_name{push, parent add}
         (
-            INDENTATION{parent longer, append, suppress} program_element
-            (INDENTATION{last, suppress} program_element)*
+            INDENTATION{parent list longer, list append, suppress} program_element
+            (INDENTATION{list last, suppress} program_element)*
         )?
-        INDENTATION{parent last, try remove, suppress} FUNCTION_END function_name{pop}
+        INDENTATION{parent list last, list try remove, suppress} FUNCTION_END function_name{pop}
     );
 
 

--- a/arpeggio/tests/test_peg_indentation.py
+++ b/arpeggio/tests/test_peg_indentation.py
@@ -76,7 +76,7 @@ class Debugging(enum.Flag):
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_parent_last_last_longer(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -104,7 +104,7 @@ end of function_name2
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrong_indentation(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -135,7 +135,7 @@ end of function_name2
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrong_indentation_at_end(klass, grammar_cb, debug, capsys):
     input_text = """

--- a/arpeggio/tests/test_peg_indentation_using_same.py
+++ b/arpeggio/tests/test_peg_indentation_using_same.py
@@ -41,11 +41,8 @@ function_call <-
     ARGUMENTS_START
     (
         VALID_NAME
-        (
-            ARGUMENTS_DELIMITER
-            VALID_NAME
-        )*
-    )?
+        % ARGUMENTS_DELIMITER
+    )*
     ARGUMENTS_DELIMITER?
     ARGUMENTS_END;
 

--- a/arpeggio/tests/test_peg_indentation_using_same.py
+++ b/arpeggio/tests/test_peg_indentation_using_same.py
@@ -1,0 +1,159 @@
+#######################################################################
+# Name: test_peg_indentation_using_same
+# Purpose: Test actions that can be used to parse indentation.
+# Authors: Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>, Andrey N. Dotsenko <pgandrey@yandex.ru>
+# Copyright: (c) 2025
+#           Igor R. Dejanović <igor DOT dejanovic AT gmail DOT com>,
+#           Andrey N. Dotsenko <pgandrey@yandex.ru>
+# License: MIT License
+#
+# This file is originally based on test_peg_indentation.py
+#######################################################################
+
+import pytest
+
+from arpeggio import NoMatch
+from arpeggio.peg import ParserPEG
+from arpeggio.cleanpeg import ParserPEG as ParserPEGClean
+import enum
+
+
+# Functions are used instead of variables to store grammar only to make parametrized test results readable
+def get_grammar():
+    return r'''
+parser_entry <-
+    (block_indentation program_element)*
+    EOF;
+
+program_element <-
+    function
+    / function_call;
+
+function <-
+    @(
+        FUNCTION_START function_name{push}
+        (block_indentation program_element)*
+        block_indentation FUNCTION_END function_name{pop}
+    );
+
+function_call <-
+    function_name
+    ARGUMENTS_START
+    VALID_NAME?
+    (
+        ARGUMENTS_DELIMITER
+        VALID_NAME
+    )*
+    ARGUMENTS_DELIMITER?
+    ARGUMENTS_END;
+
+block_indentation <- INDENTATION{first longer, other same};
+
+FUNCTION_START <- 'def';
+function_name <- VALID_NAME;
+FUNCTION_END <- 'end of';
+ARGUMENTS_START <- '(';
+ARGUMENTS_END <- ')';
+VALID_NAME <- r'[a-zA-Z0-9_]+';
+ARGUMENTS_DELIMITER <- ',';
+INDENTATION <- r'_*';
+'''
+
+
+def get_clean_grammar():
+    return get_grammar().replace('<-', '=').replace(';', '')
+
+
+class Debugging(enum.Flag):
+    ENABLED = True
+    DISABLED = False
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_first_longer_and_other_same(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+____def inner_function_name
+________function_name1(1, 2, 3)
+________function_name2(4, 5, 6)
+____end of inner_function_name
+end of function_name2
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_wrong_indentation(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+
+____def inner_function_name
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+____end of inner_function_name
+end of function_name2
+
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    with pytest.raises(NoMatch):
+        parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_wrong_indentation_at_end(klass, grammar_cb, debug, capsys):
+    input_text = """
+def function_name1
+end of function_name1
+
+def function_name2
+____function_name1(1, 2, 3)
+____function_name2(4, 5, 6)
+
+____def inner_function_name
+______function_name1(1, 2, 3)
+______function_name2(4, 5, 6)
+___end of inner_function_name
+end of function_name2
+
+"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    with pytest.raises(NoMatch):
+        parser.parse(input_text)

--- a/arpeggio/tests/test_peg_indentation_using_same.py
+++ b/arpeggio/tests/test_peg_indentation_using_same.py
@@ -71,7 +71,7 @@ class Debugging(enum.Flag):
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_first_longer_and_other_same(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -99,7 +99,7 @@ end of function_name2
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrong_indentation(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -130,7 +130,7 @@ end of function_name2
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrong_indentation_at_end(klass, grammar_cb, debug, capsys):
     input_text = """
@@ -161,7 +161,7 @@ end of function_name2
 @pytest.mark.parametrize('klass, grammar_cb, debug', [
     (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
     (ParserPEG, get_grammar, Debugging.DISABLED),
-    (ParserPEG, get_grammar, True),
+    (ParserPEG, get_grammar, Debugging.ENABLED),
 ])
 def test_wrong_indentation_at_program_start(klass, grammar_cb, debug, capsys):
     input_text = """____def function_name1

--- a/arpeggio/tests/test_peg_indentation_using_same.py
+++ b/arpeggio/tests/test_peg_indentation_using_same.py
@@ -39,11 +39,13 @@ function <-
 function_call <-
     function_name
     ARGUMENTS_START
-    VALID_NAME?
     (
-        ARGUMENTS_DELIMITER
         VALID_NAME
-    )*
+        (
+            ARGUMENTS_DELIMITER
+            VALID_NAME
+        )*
+    )?
     ARGUMENTS_DELIMITER?
     ARGUMENTS_END;
 

--- a/arpeggio/tests/test_peg_indentation_using_same.py
+++ b/arpeggio/tests/test_peg_indentation_using_same.py
@@ -157,3 +157,21 @@ end of function_name2
     )
     with pytest.raises(NoMatch):
         parser.parse(input_text)
+
+
+@pytest.mark.parametrize('klass, grammar_cb, debug', [
+    (ParserPEGClean, get_clean_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, Debugging.DISABLED),
+    (ParserPEG, get_grammar, True),
+])
+def test_wrong_indentation_at_program_start(klass, grammar_cb, debug, capsys):
+    input_text = """____def function_name1
+____end of function_name1"""
+    parser: ParserPEG = klass(
+        grammar_cb(),
+        'parser_entry',
+        debug = debug,  # noqa: E251
+        reduce_tree = True,  # noqa: E251
+    )
+    with pytest.raises(NoMatch):
+        parser.parse(input_text)

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -286,17 +286,17 @@ A set of basic **match actions** if provided:
   If the matched token and the token at the bottom of the stack aren't
   the same, then the match will fail. This action can be used to implement
   FIFO (First In, First Out) rules.
-- **add** to add a matched token to the list of the matched tokens
+- **add** to add a matched token to the set of the matched tokens
   corresponding to the rule. This action always succeeds and can be used,
   for example, to determine local variables.
-- **parent add** to add a matched token to the list of the matched tokens of
+- **parent add** to add a matched token to the set of the matched tokens of
   the parent state layer corresponding to the rule. This action always succeeds
   and can be used, for example, to determine local variables.
-- **global add** to add a matched token to the list of the matched tokens of
+- **global add** to add a matched token to the set of the matched tokens of
   the global state layer corresponding to the rule. This action always succeeds
   and can be used, for example, to determine global variables.
 - **any** to match any token corresponding to the rule that was previously
-  added to the list of matched tokens (by **add** action) across all the state
+  added to the set of matched tokens (by **add** action) across all the state
   layers. If no token found, then the rule will fail to match.
 - **list append** to add a token to the current state layer according to
   the rule name.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -278,6 +278,9 @@ A set of basic **match actions** if provided:
 - **parent add** to add a matched token to the list of the matched tokens of
   the parent state layer corresponding to the rule. This action always succeeds
   and can be used, for example, to determine local variables.
+- **global add** to add a matched token to the list of the matched tokens of
+  the global state layer corresponding to the rule. This action always succeeds
+  and can be used, for example, to determine global variables.
 - **any** to match any token corresponding to the rule that were previously
   added to the list of matched tokens (by **add** action) across all the state
   layers. If no token found, then the rule will fail to match.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -35,7 +35,7 @@ by end of input (`EOF`). `second` rule is ordered choice and will match either
     parse as far as it can, leaving the rest of the input unprocessed, and return
     without an error. So, be sure to always end your root rule sequence with
     `EOF` if you want a complete parse.
-    
+
 
 During parsing each successfully matched rule will create a parse tree node. At
 the end of parsing a complete [parse tree](parse_trees.md) of the input will be
@@ -238,7 +238,42 @@ Each grammar rule is given as an assignment where the LHS is the rule name (e.g.
   used in the grammar above).
 - **Not predicate** is specified by `!` operator (e.g. `!expression` - not
   used in the grammar above).
+- **Match actions** are special commands written within `{` and `}` braces
+  after a rule (e.g. `some_rule{push, add}`). These commands will be executed
+  after the rule has been matched. Each command can have arguments separated
+  with the whitespace. If more than one command is specified, the commands
+  must be separated by comma `,` delimiter. See below for the list
+  of the provided actions.
+- **State match** expression is an expression preceded by an expected state
+  specified within `[` and `]` braces (e.g. `[some_state]some_rule`).
+  These expressions can be matched only if the current state's name is the same
+  as the specified in the match state expression. The current state can be
+  changed with the match actions.
 - A special rule `EOF` will match end of input string.
+
+A set of basic **match actions** if provided:
+- **push** to push a matched token onto the stack. This action always succeeds.
+- **pop** to match against the token at the top of the stack corresponding
+  to the rule and pop that token from the stack. If the matched token and
+  the token at the top of the stack aren't the same, then the match will fail.
+- **pop_front** to match against the token at the bottom of the stack
+  corresponding to the rule and remove that token from the stack.
+  If the matched token and the token at the bottom of the stack aren't
+  the same, then the match will fail. This action can be used to implement
+  FIFO (First In, First Out) rules.
+- **add** to add a matched token to the list of matched tokens corresponding
+  to the rule. This action always succeeds and can be used, for example,
+  to determine local variables.
+- **any** to match any token corresponding to the rule that were previously
+  added to the list of matched tokens (by **add** action). If no token found,
+  then the rule will fail to match.
+- **state push** to push a state onto the states stack
+  (e.g. `state push my_state`). The name of the state if specified as
+  an argument of the action.
+- **state pop** to pop the specified state (e.g. `state pop my_state`) or
+  the last state (e.g. `state pop`) from the top of the states stack.
+  If the state is specified, and it doesn't match the state from the top of
+  the states stack, then the match will fail.
 
 In the RHS a rule reference is a name of another rule. Parser will try to match
 another rule at that location.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -292,10 +292,10 @@ A set of basic **match actions** if provided:
 - **global add** to add a matched token to the list of the matched tokens of
   the global state layer corresponding to the rule. This action always succeeds
   and can be used, for example, to determine global variables.
-- **any** to match any token corresponding to the rule that were previously
+- **any** to match any token corresponding to the rule that was previously
   added to the list of matched tokens (by **add** action) across all the state
   layers. If no token found, then the rule will fail to match.
-- **suppress** to suppress the rule so it wouldn't appear in the resulting
+- **suppress** to suppress a rule so it wouldn't appear in the resulting
   parsing tree.
 
 In the RHS a rule reference is a name of another rule. Parser will try to match

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -244,6 +244,22 @@ Each grammar rule is given as an assignment where the LHS is the rule name (e.g.
   with the whitespace. If more than one command is specified, the commands
   must be separated by comma `,` delimiter. See below for the list
   of the provided actions.
+- **State matches** are given as state names preceded by `@` operator
+  (e.g. `@some_state`). A match will succeed only if the current state is
+  the same as the provided by the operator state.
+- **Push state** is used to push a state onto the stack of the states and
+  make it the current. It is specified using `+@` operator with a state name
+  after it (e.g. `+@some_state`). Later this state can be matched using
+  the `@` operator. This rule always succeeds.
+- **Pop state** is used to pop a state form the top of the state stack.
+  It is specified using `-@` operator followed by the state name that should
+  be removed (e.g. `-@some_state`). If the current state doesn't match
+  the specified state then the match fails.
+- **Wrapping with a state layer** is specified using `@(` and `)` operator and
+  allows one or more rules to be wrapped with a separate state layer
+  (e.g. `@( ((LOCAL variable_name{add}) / (variable_name{any} ASSIGN value))* )`).
+  It allows to store added by actions data in separate layers (for example,
+  to handle local variables).
 - A special rule `EOF` will match end of input string.
 
 A set of basic **match actions** if provided:
@@ -256,12 +272,15 @@ A set of basic **match actions** if provided:
   If the matched token and the token at the bottom of the stack aren't
   the same, then the match will fail. This action can be used to implement
   FIFO (First In, First Out) rules.
-- **add** to add a matched token to the list of matched tokens corresponding
-  to the rule. This action always succeeds and can be used, for example,
-  to determine local variables.
+- **add** to add a matched token to the list of the matched tokens
+  corresponding to the rule. This action always succeeds and can be used,
+  for example, to determine local variables.
+- **parent add** to add a matched token to the list of the matched tokens of
+  the parent state layer corresponding to the rule. This action always succeeds
+  and can be used, for example, to determine local variables.
 - **any** to match any token corresponding to the rule that were previously
-  added to the list of matched tokens (by **add** action). If no token found,
-  then the rule will fail to match.
+  added to the list of matched tokens (by **add** action) across all the state
+  layers. If no token found, then the rule will fail to match.
 
 In the RHS a rule reference is a name of another rule. Parser will try to match
 another rule at that location.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -92,7 +92,7 @@ Here is an example of arpeggio grammar for simple calculator:
     def calc():       return OneOrMore(expression), EOF
 
 Each rule is given in the form of Python function. Python function returns data
-structure that maps to PEG expressions.
+structure that maps to PEG expressions and state statements.
 
 - **Sequence** is represented as Python tuple.
 - **Ordered choice** is represented as Python list where each element is one
@@ -107,6 +107,17 @@ structure that maps to PEG expressions.
 - **Not predicate** is represented as an instance of `Not` class.
 - **Literal string match** is represented as string or regular expression given
   as an instance of `RegExMatch` class.
+- **Match state predicate** is represented as an instance of `MatchState` class.
+  A parsing state passed to the instance must be of `ParsingState` class.
+  The class checks if the current state is the same as the provided one.
+- **Push state command** is represented as an instance of `PushState` class.
+  A parsing state passed to the instance must be of `ParsingState` class.
+- **Pop state predicate** is represented as an instance of `PopState` class.
+  A parsing state passed to the instance must be of `ParsingState` class.
+  The class checks if the current state is the same as the provided one if any.
+- **State layer wrapper** is represented as an instance of
+  `StateLayerWrapper` class. This wrapper is used to isolate the state
+  of a specific group of rules and check its integrity.
 - **End of string/file** is recognized by the `EOF` special rule.
 
 For example, the `calc` language consists of one or more `expression` and

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -298,6 +298,22 @@ A set of basic **match actions** if provided:
 - **any** to match any token corresponding to the rule that was previously
   added to the list of matched tokens (by **add** action) across all the state
   layers. If no token found, then the rule will fail to match.
+- **list append** to add a token to the current state layer according to
+  the rule name.
+- **list try remove** to try to remove the last token from the current
+  state layer if any according to the rule name.
+- **list last** to match the last token added to the current state user list
+  according to the rule name.
+- **list longer** to match a token that is longer than the last token added
+  to the current state user list according to the rule name.
+- **parent list last** to match the last token added to the parent state user
+  list according to the rule name.
+- **parent list longer** to match a token that is longer than the last token added
+  to the parent state user list according to the rule name.
+- **other same** to match a token that is inside the repetition expression
+  only if it's always the same in every repetition.
+- **first longer** to match a token only if it's length is longer than
+  the length of the last token from the parent repetition expression.
 - **suppress** to suppress a rule so it wouldn't appear in the resulting
   parsing tree.
 

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -244,11 +244,6 @@ Each grammar rule is given as an assignment where the LHS is the rule name (e.g.
   with the whitespace. If more than one command is specified, the commands
   must be separated by comma `,` delimiter. See below for the list
   of the provided actions.
-- **State match** expression is an expression preceded by an expected state
-  specified within `[` and `]` braces (e.g. `[some_state]some_rule`).
-  These expressions can be matched only if the current state's name is the same
-  as the specified in the match state expression. The current state can be
-  changed with the match actions.
 - A special rule `EOF` will match end of input string.
 
 A set of basic **match actions** if provided:
@@ -267,13 +262,6 @@ A set of basic **match actions** if provided:
 - **any** to match any token corresponding to the rule that were previously
   added to the list of matched tokens (by **add** action). If no token found,
   then the rule will fail to match.
-- **state push** to push a state onto the states stack
-  (e.g. `state push my_state`). The name of the state if specified as
-  an argument of the action.
-- **state pop** to pop the specified state (e.g. `state pop my_state`) or
-  the last state (e.g. `state pop`) from the top of the states stack.
-  If the state is specified, and it doesn't match the state from the top of
-  the states stack, then the match will fail.
 
 In the RHS a rule reference is a name of another rule. Parser will try to match
 another rule at that location.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -295,6 +295,8 @@ A set of basic **match actions** if provided:
 - **any** to match any token corresponding to the rule that were previously
   added to the list of matched tokens (by **add** action) across all the state
   layers. If no token found, then the rule will fail to match.
+- **suppress** to suppress the rule so it wouldn't appear in the resulting
+  parsing tree.
 
 In the RHS a rule reference is a name of another rule. Parser will try to match
 another rule at that location.

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -240,8 +240,11 @@ Each grammar rule is given as an assignment where the LHS is the rule name (e.g.
 - **Optional** expression is specified by `?`operator (e.g. `expression?`) and
   matches zero or one occurrence of *expression*
 - **Zero or more** expression is specified by `*` operator (e.g. `(( "*" /
-  "/" ) factor)*`).
+  "/" ) factor)*`). Additionally, a separator could be specified
+  by `%` operator (e.g. `(argument % ',')*`).
 - **One of more** is specified by `+` operator (e.g. `expression+`).
+  Additionally, a separator could be specified by `%` operator
+  (e.g. `(argument % ',')+`).
 - **Unordered group** is specified by `#` operator (e.g. `sequence#`). It has
   sense only if applied to the sequence expression. Elements of the sequence are
   matched in any order.

--- a/examples/peg_peg/peg.peg
+++ b/examples/peg_peg/peg.peg
@@ -1,9 +1,9 @@
  peggrammar <- rule+ EOF;
  rule <- rule_name LEFT_ARROW ordered_choice ';';
  ordered_choice <- sequence (SLASH sequence)*;
- sequence <- prefix+;
- prefix <- (AND/NOT)? sufix;
- sufix <- expression (QUESTION/STAR/PLUS)?;
+ sequence <- full_expression+;
+ full_expression <- (AND/NOT)? repeated_expression;
+ repeated_expression <- expression (QUESTION/STAR/PLUS)?;
  expression <- regex / rule_crossref
                 / (OPEN ordered_choice CLOSE) / str_match;
 

--- a/examples/peg_peg/peg_peg.py
+++ b/examples/peg_peg/peg_peg.py
@@ -56,6 +56,6 @@ def main(debug=False):
     parser.parser_model = parser_model
     parser.parse(peg_grammar)
 
+
 if __name__ == '__main__':
     main(debug=True)
-


### PR DESCRIPTION
The state system allows programmers to write complex grammar parsers for the languages with the unusual features.

The PEG action system allows to handle such features as  templates/generics in such programming languages like Python and Golang or to handle the labels in such languages as C (it's an automatic linkage of labels).

The parsing state system allows to handle non-linear code parsing scenarios (like cases where the syntax constructions overlap and depend on the previously found constructions during the parsing process).

Both the state and the action systems allow programmers to solve many known and possible issues that the original parser was unable to solve. Previously, such problems were, most likely, solved in the semantic layer of the program (with a much greater complexity and much less readable code).


The con of the new system is that the parsing process becomes a little slower while working with the state system because it needs to take a state snapshot every time before a match can fail.

_Updated on 2025-07-20:_

To make the tests smoother, an improvement was made to the PEG grammar notation, i.e. separator `%` operator is now available  so that writing repetitions with a separator would be much easier. Although I thought about using `,` instead, but this way the code looks too odd.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).

